### PR TITLE
Fixed references to old repository in docs

### DIFF
--- a/docs/source/SURFsara_systems.rst
+++ b/docs/source/SURFsara_systems.rst
@@ -171,7 +171,7 @@ To prepare X-PSI from ``$HOME``:
 
 .. code-block:: bash
 
-    git clone https://github.com/ThomasEdwardRiley/xpsi.git
+    git clone https://github.com/xpsi-group/xpsi.git
     cd xpsi
     LDSHARED="icc -shared" CC=icc python setup.py install --user
 
@@ -341,7 +341,7 @@ Finally, we need the Python interface to MultiNest, GSL, and X-PSI, all starting
 
 .. code-block:: bash
 
-    cd; git clone https://github.com/ThomasEdwardRiley/xpsi.git
+    cd; git clone https://github.com/xpsi-group/xpsi.git
     cd xpsi
     LDSHARED="icc -shared" CC=icc python setup.py install --user    
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -64,7 +64,7 @@ advisory workflow.
 
 .. code-block:: bash
 
-    git clone https://github.com/ThomasEdwardRiley/xpsi.git <path/to/xpsi>
+    git clone https://github.com/xpsi-group/xpsi.git <path/to/xpsi>
 
 * You will be on the ``master`` branch by default; this branch by default tracks
   the official (or central) ``origin/master`` branch. Moreover, ``master``
@@ -201,7 +201,7 @@ Most feature development by the X-PSI team is conducted on private platforms
 including a private development repository .
 
 The X-PSI team works with respect to a private centralised repository
-``xpsi_dev`` and pushes releases to a public GitHub repository. These veryy
+``xpsi_dev`` and pushes releases to a public GitHub repository. These very
 online documentation pages are only built and pushed to GitHub to be hosted,
 usually by a designated X-PSI team member responsible for this process.
 Commits directly on GitHub via pull requests (e.g., patches) are fetched and
@@ -231,8 +231,8 @@ such as:
     (xpsi) [15:24:19][xpsi]$ git remote -v
     DEV     https://ThomasEdwardRiley@bitbucket.org/ThomasEdwardRiley/xpsi_dev.git (fetch)
     DEV     https://ThomasEdwardRiley@bitbucket.org/ThomasEdwardRiley/xpsi_dev.git (push)
-    origin  https://github.com/ThomasEdwardRiley/xpsi.git (fetch)
-    origin  https://github.com/ThomasEdwardRiley/xpsi.git (push)
+    origin  https://github.com/xpsi-group/xpsi.git (fetch)
+    origin  https://github.com/xpsi-group/xpsi.git (push)
 
 If you have forked repositories (your own forks or those of other community
 members for collaborative purposes) these would also be remotes of the local

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -16,7 +16,7 @@ Clone X-PSI:
 
 .. code-block:: bash
 
-    git clone https://github.com/ThomasEdwardRiley/xpsi.git </path/to/xpsi>
+    git clone https://github.com/xpsi-group/xpsi.git </path/to/xpsi>
 
 Basic Conda environment
 -----------------------

--- a/docs/source/intro.txt
+++ b/docs/source/intro.txt
@@ -110,7 +110,7 @@ as a software acknowledgement, e.g.:
 
 .. code-block:: latex
 
-    X-PSI (\url{https://github.com/ThomasEdwardRiley/xpsi}, \citet{xpsi})
+    X-PSI (\url{https://github.com/xpsi-group/xpsi.git}, \citet{xpsi})
 
     @MISC{xpsi,
         author = {{Riley}, Thomas Edward},


### PR DESCRIPTION
The documentation is built from this repository, but the text in the docs (e.g. for installation and contributing) still refers the old repo. This is probably not what you want? 

Note: I've not touched any of the Bitbucket references, or the ones to the `xpsi_workshop` repo, because I don't know what's going on there. :) 