### PR TITLE
Additions to #28. Saves count matrix file if input only takes event file

### DIFF
--- a/xpsi/module_generator.py
+++ b/xpsi/module_generator.py
@@ -1515,7 +1515,9 @@ except ValueError:
                                          last=len({0}.instrument.channels) - 1,
                                          exposure_time=args.{0}_exposure_time)
 
-    np.savetxt(args.{0}_count_matrix_path, {0}.data.counts)
+    np.savetxt(args.{0}_event_path.replace('.txt','_converted_to_counts.txt'), {0}.data.counts)
+    print('Counts file saved as: '+args.{0}_event_path.replace('.txt','_converted_to_counts.txt'))
+    print('Update configuration file to take in counts file to save computation time.')
 else:
     if counts.ndim == 1:
         counts = counts.reshape(-1,1)


### PR DESCRIPTION
The bug in #27 turned out to be more of an unintuitive approach than a bug, leading to human errors. It was previously unclear when filing the configuration file that the count matrix path has to be necessarily provided, even if there is none. The original reason for this was that the `exception` block then generated the counts matrix file and saved it to that path, so that in later run iterations, it is used instead, thus saving computation time. 
The new workaround doesn't require a count matrix path to be necessarily provided, and saves the count matrix generated from the event file into a new file sharing the same path as the event file, and shares the same name with an added `'_converted_to_counts.txt'` to the filename. An output is also generated for the user to update the configuration file instead, and states the reason why. The only shortcoming with the new approach here being that this step has to be done manually after running the main file for the first time.