### PR TITLE
Tests for Spacetime class

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -125,6 +125,9 @@ The following Python packages are required for nested sampling:
     personal machine to gain experience on application to inexpensive test
     problems. Below we offer `from source`__ instructions.
 
+Running the tests requires:
+* `Pytest <http://pytest.org>`_
+
 The following Python packages are required for full functionality of the
 post-processing module:
 

--- a/xpsi/Spacetime.py
+++ b/xpsi/Spacetime.py
@@ -39,6 +39,10 @@ class Spacetime(ParameterSubspace):
 
     def __init__(self, bounds, values):
 
+
+        if not isinstance(bounds, dict) or not isinstance(values, dict):
+             raise TypeError("Both bounds and values need to be dictionaries.")
+
         f = Parameter('frequency',
                       strict_bounds = (0.0, 800.0),
                       bounds = bounds.get('frequency', None),

--- a/xpsi/tests/test_spacetime.py
+++ b/xpsi/tests/test_spacetime.py
@@ -34,11 +34,11 @@ class TestSpacetimeInit(object):
     def test_spacetime_class_initializes(self):
         st = Spacetime(self.bounds, self.values)
 
-    def test_spacetime_breaks_with_values_missin(self):
+    def test_spacetime_breaks_with_bounds_missing(self):
         with pytest.raises(TypeError):
             st = Spacetime(self.values)
 
-    def test_spacetime_breaks_with_bounds_missing(self):
+    def test_spacetime_breaks_with_values_missing(self):
         with pytest.raises(TypeError):
             st = Spacetime(self.bounds)
 
@@ -204,14 +204,7 @@ class TestSpacetimeProperties(object):
 
         assert st.epsilon == epsilon_val
 
-    def test_a_setter(self):
-        st = Spacetime(self.bounds, self.values)
-        aval = 42
-        st.a = aval
-
-        assert st._a == aval
-
-    def test_a_deleter(self):
+    def test_a_setter_deleter(self):
         st = Spacetime(self.bounds, self.values)
         aval = 42
         st.a = aval
@@ -221,14 +214,7 @@ class TestSpacetimeProperties(object):
         with pytest.raises(AttributeError):
             st._a
 
-    def test_q_setter(self):
-        st = Spacetime(self.bounds, self.values)
-        qval = 42
-        st.q = qval
-
-        assert st._q == qval
-
-    def test_q_deleter(self):
+    def test_q_setter_deleter(self):
         st = Spacetime(self.bounds, self.values)
         qval = 42
         st.q = qval

--- a/xpsi/tests/test_spacetime.py
+++ b/xpsi/tests/test_spacetime.py
@@ -1,10 +1,11 @@
 from __future__ import division, print_function
 
-from .Spacetime import Spacetime
+from xpsi.Spacetime import Spacetime
+import pytest
 
-def TestSpacetime(object):
+class TestSpacetime(object):
 
-    def setup_class(self):
+    def setup_class(cls):
         cls.frequency = 300.0
         cls.mass = 1.4
         cls.radius = 10.0
@@ -17,54 +18,61 @@ def TestSpacetime(object):
         cls.distance_bounds = (0.05, 25.0)
         cls.cos_inclination_bounds = (-0.9, 0.9)
 
-        cls.bounds = (self.frequency_bounds,
-                      self.mass_bounds,
-                      self.radius_bounds,
-                      self.distance_bounds,
-                      self.cos_inclination_bounds)
+        cls.bounds = {"frequency": cls.frequency_bounds,
+                      "mass": cls.mass_bounds,
+                      "radius": cls.radius_bounds,
+                      "distance": cls.distance_bounds,
+                      "cos_inclination": cls.cos_inclination_bounds}
 
-        cls.values = (self.frequency,
-                      self.mass,
-                      self.radius,
-                      self.distance,
-                      self.cos_inclination)
+        cls.values = {"frequency": cls.frequency,
+                      "mass": cls.mass,
+                      "radius": cls.radius,
+                      "distance": cls.distance,
+                      "cos_inclination": cls.cos_inclination}
 
     def test_spacetime_class_initializes(self):
         st = Spacetime(self.bounds, self.values)
 
     def test_spacetime_breaks_with_values_missin(self):
-        st = Spacetime(self.values)
+        with pytest.raises(TypeError):
+            st = Spacetime(self.values)
 
     def test_spacetime_breaks_with_bounds_missing(self):
-        st = Spacetime(self.bounds)
+        with pytest.raises(TypeError):
+            st = Spacetime(self.bounds)
 
     def test_spacetime_breaks_with_both_missing(self):
-        st = Spacetime()
+        with pytest.raises(TypeError):
+            st = Spacetime()
 
     def test_spacetime_breaks_if_inputs_switched(self):
-       st = Spacetime(self.values, self.bounds)
+       with pytest.raises(TypeError):
+           st = Spacetime(self.values, self.bounds)
 
     def test_failure_when_parameter_out_of_bounds(self):
         mass = 3.5
-        values = (self.frequency, mass, self.radius, self.distance,
-                  self.cos_inclination)
-
-        st = Spacetime(values, self.bounds)
+        values = {"frequency": self.frequency, 
+                  "mass": mass, 
+                  "radius": self.radius, 
+                  "distance": self.distance,
+                  "cos_inclination": self.cos_inclination}
+        with pytest.raises(TypeError):
+            st = Spacetime(values, self.bounds)
 
     def test_failure_when_parameter_out_of_strict_bounds(self):
         mass_bounds = (0.001, 3.5)
-        bounds = (self.frequency_bounds,
-                  mass_bounds,
-                  self.radius_bounds,
-                  self.distance_bounds,
+        bounds = {"frequency": self.frequency_bounds,
+                  "mass": mass_bounds,
+                  "radius": self.radius_bounds,
+                  "distance": self.distance_bounds,
+                  "cos_inclination": self.cos_inclination_bounds}
+        with pytest.raises(ValueError):
+            st = Spacetime(bounds, self.values)
+
+    def test_fails_when_input_is_not_dict(self):
+        bounds = (self.frequency_bounds, self.mass_bounds,
+                  self.radius_bounds, self.distance_bounds,
                   self.cos_inclination_bounds)
 
-        st = Spacetime(bounds, self.values)
-
-    def test_failure_when_input_none(self):
-        mass = None
-        values = (self.frequency, mass, self.radius, self.distance, 
-                  self.cos_inclination)
-        st = Spacetime(self.bounds, self.values)
-
-
+        with pytest.raises(TypeError):
+            st = Spacetime(bounds, self.values)

--- a/xpsi/tests/test_spacetime.py
+++ b/xpsi/tests/test_spacetime.py
@@ -1,0 +1,70 @@
+from __future__ import division, print_function
+
+from .Spacetime import Spacetime
+
+def TestSpacetime(object):
+
+    def setup_class(self):
+        cls.frequency = 300.0
+        cls.mass = 1.4
+        cls.radius = 10.0
+        cls.distance = 3.0
+        cls.cos_inclination = 0.6
+
+        cls.frequency_bounds = (0.1, 750.0)
+        cls.mass_bounds = (0.01, 2.5)
+        cls.radius_bounds = (5.0, 15.0)
+        cls.distance_bounds = (0.05, 25.0)
+        cls.cos_inclination_bounds = (-0.9, 0.9)
+
+        cls.bounds = (self.frequency_bounds,
+                      self.mass_bounds,
+                      self.radius_bounds,
+                      self.distance_bounds,
+                      self.cos_inclination_bounds)
+
+        cls.values = (self.frequency,
+                      self.mass,
+                      self.radius,
+                      self.distance,
+                      self.cos_inclination)
+
+    def test_spacetime_class_initializes(self):
+        st = Spacetime(self.bounds, self.values)
+
+    def test_spacetime_breaks_with_values_missin(self):
+        st = Spacetime(self.values)
+
+    def test_spacetime_breaks_with_bounds_missing(self):
+        st = Spacetime(self.bounds)
+
+    def test_spacetime_breaks_with_both_missing(self):
+        st = Spacetime()
+
+    def test_spacetime_breaks_if_inputs_switched(self):
+       st = Spacetime(self.values, self.bounds)
+
+    def test_failure_when_parameter_out_of_bounds(self):
+        mass = 3.5
+        values = (self.frequency, mass, self.radius, self.distance,
+                  self.cos_inclination)
+
+        st = Spacetime(values, self.bounds)
+
+    def test_failure_when_parameter_out_of_strict_bounds(self):
+        mass_bounds = (0.001, 3.5)
+        bounds = (self.frequency_bounds,
+                  mass_bounds,
+                  self.radius_bounds,
+                  self.distance_bounds,
+                  self.cos_inclination_bounds)
+
+        st = Spacetime(bounds, self.values)
+
+    def test_failure_when_input_none(self):
+        mass = None
+        values = (self.frequency, mass, self.radius, self.distance, 
+                  self.cos_inclination)
+        st = Spacetime(self.bounds, self.values)
+
+

--- a/xpsi/tests/test_spacetime.py
+++ b/xpsi/tests/test_spacetime.py
@@ -203,3 +203,38 @@ class TestSpacetimeProperties(object):
         st._epsilon = epsilon_val
 
         assert st.epsilon == epsilon_val
+
+    def test_a_setter(self):
+        st = Spacetime(self.bounds, self.values)
+        aval = 42
+        st.a = aval
+
+        assert st._a == aval
+
+    def test_a_deleter(self):
+        st = Spacetime(self.bounds, self.values)
+        aval = 42
+        st.a = aval
+
+        assert st._a == aval
+        del st.a
+        with pytest.raises(AttributeError):
+            st._a
+
+    def test_q_setter(self):
+        st = Spacetime(self.bounds, self.values)
+        qval = 42
+        st.q = qval
+
+        assert st._q == qval
+
+    def test_q_deleter(self):
+        st = Spacetime(self.bounds, self.values)
+        qval = 42
+        st.q = qval
+        
+        assert st._q == qval
+        del st.q
+        with pytest.raises(AttributeError):
+            st._q
+ 

--- a/xpsi/tests/test_spacetime.py
+++ b/xpsi/tests/test_spacetime.py
@@ -1,9 +1,10 @@
 from __future__ import division, print_function
 
+import numpy as np
 from xpsi.Spacetime import Spacetime
 import pytest
 
-class TestSpacetime(object):
+class TestSpacetimeInit(object):
 
     def setup_class(cls):
         cls.frequency = 300.0
@@ -76,3 +77,129 @@ class TestSpacetime(object):
 
         with pytest.raises(TypeError):
             st = Spacetime(bounds, self.values)
+
+
+class TestSpacetimeProperties(object):
+
+    def setup_class(cls):
+        cls.frequency = 100.0
+        cls.mass = 1.0
+        cls.radius = 10.0
+        cls.distance = 3.0
+        cls.cos_inclination = -1.0
+
+        cls.frequency_bounds = (0.1, 750.0)
+        cls.mass_bounds = (0.01, 2.5)
+        cls.radius_bounds = (5.0, 15.0)
+        cls.distance_bounds = (0.05, 25.0)
+        cls.cos_inclination_bounds = (-1.0, 0.9)
+
+        cls.bounds = {"frequency": cls.frequency_bounds,
+                      "mass": cls.mass_bounds,
+                      "radius": cls.radius_bounds,
+                      "distance": cls.distance_bounds,
+                      "cos_inclination": cls.cos_inclination_bounds}
+
+        cls.values = {"frequency": cls.frequency,
+                      "mass": cls.mass,
+                      "radius": cls.radius,
+                      "distance": cls.distance,
+                      "cos_inclination": cls.cos_inclination}
+
+        cls.st = Spacetime(cls.bounds, cls.values)
+
+        cls.rg_sun = 2.95*10**3
+        cls.msun =  1.989*10**30
+
+    def test_M_works(self):
+        self.st.M
+
+    def test_M_is_correct(self):
+        assert np.isclose(self.msun, self.st.M, rtol=0.001)
+
+    def test_rg_runs(self):
+        self.st.r_g
+
+    def test_rg_is_correct(self):
+        # XPSI definition of R_g includes a factor of
+        # 2 elsewhere, hence the division by 2 below
+        rg_sun = self.rg_sun / 2
+        assert np.isclose(rg_sun, self.st.r_g, rtol=0.002)
+
+    def test_schwarzschild_radius_computes(self):
+        self.st.r_s
+
+    def test_rs_is_correct(self):
+        assert np.isclose(self.rg_sun, self.st.r_s , rtol=0.002)
+
+    def test_r_computes(self):
+        self.st.R
+
+    def test_r_is_correct(self):
+        assert self.st.R == self.radius * 1000
+
+    def test_rrs_computes(self):
+        self.st.R_r_s
+
+    def test_rrs_is_correct(self):
+        ratio = self.radius * 1000.0 / self.rg_sun
+        assert np.isclose(self.st.R_r_s, ratio, rtol=0.002)
+
+    def test_f_computes(self):
+        self.st.f
+
+    def test_f_is_correct(self):
+        assert self.st.f == self.frequency
+
+    def test_omega_computes(self):
+        self.st.Omega
+
+    def test_omega_is_correct(self):
+        assert self.st.Omega == 2 * np.pi * self.frequency
+
+    def test_i_computes(self):
+        self.st.i
+
+    def test_i_is_correct(self):
+        assert self.st.i == np.pi
+
+    def test_d_computes(self):
+        self.st.d
+
+    def test_d_is_correct(self):
+        dist = self.distance * 3.086 * 10**16 * 1000.0
+        assert np.isclose(self.st.d, dist, rtol=0.001)
+
+    def test_dsq_computes(self):
+        self.st.d_sq
+
+    def test_dsq_correct(self):
+        dist = (self.distance * 3.086 * 10**16 * 1000.0) ** 2.0
+        assert np.isclose(self.st.d_sq, dist, rtol=0.001) 
+
+    def test_zeta_gets_calculated(self):
+        zeta = (self.rg_sun / 2.) / (self.radius * 1000.0)
+        assert np.isclose(zeta, self.st.zeta, rtol=0.002)
+
+    def test_zeta_gets_returned_upon_calculation(self):
+        st = Spacetime(self.bounds, self.values)
+        zeta_val = 42
+        st._zeta = zeta_val
+
+        assert st.zeta == zeta_val
+
+    def test_epsilon_gets_calculated(self):
+        omega_sq = (2. * np.pi * self.frequency) ** 2.0
+        r_cubed = (self.radius * 1000) ** 3.0
+        grav_const = 6.6743e-11
+        gm = grav_const  * self.msun
+        eps = omega_sq * r_cubed / gm
+
+        assert np.isclose(eps, self.st.epsilon, rtol=0.001) 
+
+    def test_epsilon_gets_returned_upon_calculation(self):
+        st = Spacetime(self.bounds, self.values)
+        epsilon_val = 42
+        st._epsilon = epsilon_val
+
+        assert st.epsilon == epsilon_val


### PR DESCRIPTION
This patch contains a new script `test_spacetime.py` in a new folder `tests` within the XPSI code folder. This contains tests for the `Spacetime` class, using the pytest package for testing. I've also added a line to the docs to mention that for running the tests, the pytest package is required. 

Once these tests are merged, I can start working on getting the automated testing infrastructure to work :) 