### PR TITLE
References to `HPC systems` corrected in different docs.

### DIFF
--- a/docs/source/FAQ.rst
+++ b/docs/source/FAQ.rst
@@ -22,7 +22,7 @@ in a context where performance matters.
 
 If you want to test the binaries on a login node, note that you can
 compile with multiple instruction sets for auto-dispatch using the ``-x`` and
-``-ax`` flags. See the :ref:`surfsystems` page for examples.
+``-ax`` flags. See the :ref:`hpcsystems` page for examples.
 
 .. rubric:: What atmosphere extension should I use?
 
@@ -67,6 +67,6 @@ in :ref:`R19`, hereafter R19).
 
 Disk storage required is indeed small: up to :math:`\mathcal{O}(100)` Mbytes for
 applications thus far (e.g., R19). There is a variant of MultiNest nested sampling
-that is much more memory and disk intensive, but we do not use it.  This is 
-because importance nested sampling is not compatible with the alternative options 
+that is much more memory and disk intensive, but we do not use it.  This is
+because importance nested sampling is not compatible with the alternative options
 (read: hacks) for prior implementation (see `Riley, PhD thesis <https://hdl.handle.net/11245.1/aa86fcf3-2437-4bc2-810e-cf9f30a98f7a>`_).

--- a/docs/source/example_script.rst
+++ b/docs/source/example_script.rst
@@ -14,7 +14,7 @@ where ``main.py`` is of course the script name, and where for a machine with
 four physical cores, we spawn as many MPI processes.
 
 .. note:: Make sure to set OpenMP environment variables appropriately
-          (see, e.g., :ref:`surfsystems`) to avoid hybrid parallelisation by
+          (see, e.g., :ref:`hpcsystems`) to avoid hybrid parallelisation by
           libraries linked to NumPy and GSL, for instance.
 
 The optional ``-m`` argument is to run the module :mod:`mpi4py` as main, which

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -93,7 +93,7 @@ to add *conda-forge* package channel.
     you are free to set up alternative environment. For installation on a
     high-performance system, instructions on this page, which tailor to a
     self-administered machine, are either not applicable or do not target
-    performance. We direct the reader to the :ref:`surfsystems` page for
+    performance. We direct the reader to the :ref:`hpcsystems` page for
     guidance.
 
 To duplicate from file:


### PR DESCRIPTION
Fixes #126 