### PR TITLE
Links to updated publications and Zenodos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ make sure you take a look at the `Code of Conduct <https://xpsi-group.github.io/
 Citing XPSI
 -----------
 If you find this package useful in your research, please provide the appropriate acknowledgment 
-and citation. `Our documentation <https://xpsi-group.github.io/xpsi/index.html#citation>`_ provides 
+and citation. `Our documentation <https://xpsi-group.github.io/xpsi/citation.html>`_ provides 
 more detail, including links to appropriate papers and BibTeX entries.
 
 Copyright and Licensing

--- a/docs/source/Instrument_synergy.ipynb
+++ b/docs/source/Instrument_synergy.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To run this tutorial, you should install X-PSI with the default (blackbody) atmosphere extension module, which is compiled when installing X-PSI with default settings. Some data files are needed and they can be found in the [Zenodo](https://zenodo.org/record/7094145)."
+    "To run this tutorial, you should install X-PSI with the default (blackbody) atmosphere extension module, which is compiled when installing X-PSI with default settings. Some data files are needed and they can be found in the [Zenodo](https://zenodo.org/record/7094144)."
    ]
   },
   {

--- a/docs/source/Modeling.ipynb
+++ b/docs/source/Modeling.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To run this tutorial, you should install X-PSI with the default (blackbody) atmosphere extension module, which is compiled when installing X-PSI with default settings. Some data files are needed and they can be found in the [Zenodo](https://zenodo.org/record/7094145)."
+    "To run this tutorial, you should install X-PSI with the default (blackbody) atmosphere extension module, which is compiled when installing X-PSI with default settings. Some data files are needed and they can be found in the [Zenodo](https://zenodo.org/record/7094144)."
    ]
   },
   {

--- a/docs/source/Start_here.rst
+++ b/docs/source/Start_here.rst
@@ -4,7 +4,7 @@
 Start here
 ==========
 
-All tutorials listed below may be found as Jupyter notebooks under ``docs/source/``. We encourage running these yourself as you go through the tutorials as a means of practice. Any external data files needed such as instrument response files and numerical atmosphere data are available on `Zenodo <https://doi.org/10.5281/zenodo.7094145>`_. These data files should be saved in ``examples/examples_modeling_tutorial/model_data/``.
+All tutorials listed below may be found as Jupyter notebooks under ``docs/source/``. We encourage running these yourself as you go through the tutorials as a means of practice. Any external data files needed such as instrument response files and numerical atmosphere data are available on `Zenodo <https://doi.org/10.5281/zenodo.7094144>`_. These data files should be saved in ``examples/examples_modeling_tutorial/model_data/``.
 
 **Overview of the available tutorials:**
 

--- a/docs/source/Surface_radiation_field_tools.ipynb
+++ b/docs/source/Surface_radiation_field_tools.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "For the first part of this tutorial, you should install X-PSI with the default (blackbody) atmosphere extension module, which is compiled when installing X-PSI with default settings. Then run the full the tutorial **except the one code block under the title \"Isotropic blackbody\"** after re-installing X-PSI using the numerical atmosphere extension using the ``NumHot`` and ``NumElse`` options and re-starting the IPython kernel.\n",
     "\n",
-    "The required atmosphere data files are needed and they can be found in the [Zenodo](https://zenodo.org/record/7094145)."
+    "The required atmosphere data files are needed and they can be found in the [Zenodo](https://zenodo.org/record/7094144)."
    ]
   },
   {

--- a/docs/source/applications.rst
+++ b/docs/source/applications.rst
@@ -11,6 +11,26 @@ papers for full details of settings and resource consumption.
 If you have used X-PSI for a project and have time to summarise it here, please
 contact the X-PSI team and/or submit a pull-request on GitHub.
 
+.. _S22:
+
+`Salmi et al. 2022 (ApJ in press)`__
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. _ADS22: https://ui.adsabs.harvard.edu/abs/2022arXiv220912840S/abstract
+
+__ ADS22_
+
+`Salmi et al. (2022; hereafter S22)`__ used ``v0.7.10`` of X-PSI to model
+*NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0740+6620 using *NICER*
+background estimates.
+
+__ ADS22_
+
+See also the associated `Zenodo repository`__.
+
+.. _Zenodo22: https://doi.org/10.5281/zenodo.6827536
+__ Zenodo22_
+
 
 .. _R21:
 


### PR DESCRIPTION
Corrects Zenodo link for auxiliary tutorial files to most up-to-date version (close issue #166)
Adds link to Salmi et al. 2022 in Applications (close issue #169 )
