### PR TITLE
Minor corrections to installation documentation

### DIFF
--- a/docs/source/HPC_systems.rst
+++ b/docs/source/HPC_systems.rst
@@ -141,7 +141,7 @@ Use the last command to check for the presence of shared objects.
 
 .. note::
 
-    The Intel compilers on Snellius run into issues with Intel Math Kernal Library (MKL) due to static linkage. These issues can be solved by setting the appropriate paths to the environment variable for the pre-load libs:
+    The Intel compilers on Snellius may run into issues with Intel Math Kernel Library (MKL) due to static linkage. These issues can be solved by setting the appropriate paths to the environment variable for the pre-load libs:
 
     .. code-block:: bash
 
@@ -149,7 +149,7 @@ Use the last command to check for the presence of shared objects.
 
     Further details on MKL issues can be found in this `thread <https://community.intel.com/t5/Intel-oneAPI-Math-Kernel-Library/mkl-fails-to-load/m-p/1155538>`_
 
-We also need to the set the environment variable for library path to point at MultiNest:
+We also need to set the environment variable for the library path to point at MultiNest:
 
 .. code-block:: bash
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -292,6 +292,12 @@ might be best set to somewhere between the number of physical cores and
 logical cores in your machine for test sampling applications. For a typical
 laptop that might be up to ``-n 4``.
 
+You also need to set the environment variable for the library path to point at MultiNest:
+
+.. code-block:: bash
+
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/multinest/MultiNest_v3.12_CMake/multinest/lib/
+
 Now you need the Python interface to MultiNest:
 
 .. code-block:: bash


### PR DESCRIPTION
Added the line about setting the environment variable for the library path to point to Multinest, which was previously on the HPC instructions page, to the main installation page.

Corrected some minor typos. 

Addresses issue #187 