### PR TITLE
Make mandatory channel_edges argument in CustomInstrument

### DIFF
--- a/docs/source/Instrument_synergy.ipynb
+++ b/docs/source/Instrument_synergy.ipynb
@@ -346,8 +346,7 @@
     "        try:\n",
     "            ARF = np.loadtxt(ARF, dtype=np.double, skiprows=3)\n",
     "            RMF = np.loadtxt(RMF, dtype=np.double)\n",
-    "            if channel_edges:\n",
-    "                channel_edges = np.loadtxt(channel_edges, dtype=np.double, skiprows=3)[:,1:]\n",
+    "            channel_edges = np.loadtxt(channel_edges, dtype=np.double, skiprows=3)[:,1:]\n",
     "        except:\n",
     "            print('A file could not be loaded.')\n",
     "            raise\n",
@@ -397,9 +396,9 @@
    "source": [
     "NICER.instrument = CustomInstrument.from_response_files(ARF = '../../examples/examples_modeling_tutorial/model_data/nicer_v1.01_arf.txt',\n",
     "                                         RMF = '../../examples/examples_modeling_tutorial/model_data/nicer_v1.01_rmf_matrix.txt',\n",
+    "                                         channel_edges = '../../examples/examples_modeling_tutorial/model_data/nicer_v1.01_rmf_energymap.txt',\n",
     "                                         max_input = 500,\n",
-    "                                         min_input = 0,\n",
-    "                                         channel_edges = '../../examples/examples_modeling_tutorial/model_data/nicer_v1.01_rmf_energymap.txt')"
+    "                                         min_input = 0)"
    ]
   },
   {
@@ -428,12 +427,12 @@
    ],
    "source": [
     "XMM.instrument = CustomInstrument.from_response_files(ARF = '../../examples/examples_modeling_tutorial/model_data/nicer_v1.01_arf.txt',\n",
-    "                                       scaling = 0.5,\n",
     "                                       RMF = '../../examples/examples_modeling_tutorial/model_data/nicer_v1.01_rmf_matrix.txt',\n",
+    "                                       channel_edges = '../../examples/examples_modeling_tutorial/model_data/nicer_v1.01_rmf_energymap.txt',\n",
     "                                       max_input = 500,\n",
     "                                       min_input = 0,\n",
-    "                                       channel_edges = '../../examples/examples_modeling_tutorial/model_data/nicer_v1.01_rmf_energymap.txt',\n",
-    "                                       translate_edges = 0.1)"
+    "                                       translate_edges = 0.1,\n",
+    "                                       scaling = 0.5)"
    ]
   },
   {
@@ -1864,7 +1863,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/Instrument_synergy.ipynb
+++ b/docs/source/Instrument_synergy.ipynb
@@ -1863,7 +1863,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/docs/source/Modeling.ipynb
+++ b/docs/source/Modeling.ipynb
@@ -590,8 +590,7 @@
     "        try:\n",
     "            ARF = np.loadtxt(ARF, dtype=np.double, skiprows=3)\n",
     "            RMF = np.loadtxt(RMF, dtype=np.double)\n",
-    "            if channel_edges:\n",
-    "                channel_edges = np.loadtxt(channel_edges, dtype=np.double, skiprows=3)[:,1:]\n",
+    "            channel_edges = np.loadtxt(channel_edges, dtype=np.double, skiprows=3)[:,1:]\n",
     "        except:\n",
     "            print('A file could not be loaded.')\n",
     "            raise\n",
@@ -635,9 +634,9 @@
    "source": [
     "NICER = CustomInstrument.from_response_files(ARF = '../../examples/examples_modeling_tutorial/model_data/nicer_v1.01_arf.txt',\n",
     "                                             RMF = '../../examples/examples_modeling_tutorial/model_data/nicer_v1.01_rmf_matrix.txt',\n",
+    "                                             channel_edges = '../../examples/examples_modeling_tutorial/model_data/nicer_v1.01_rmf_energymap.txt',\n",
     "                                             max_input = 500,\n",
-    "                                             min_input = 0,\n",
-    "                                             channel_edges = '../../examples/examples_modeling_tutorial/model_data/nicer_v1.01_rmf_energymap.txt')"
+    "                                             min_input = 0)"
    ]
   },
   {
@@ -4639,7 +4638,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/docs/source/Modeling.ipynb
+++ b/docs/source/Modeling.ipynb
@@ -11,7 +11,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To run this tutorial, you should install X-PSI with the default (blackbody) atmosphere extension module, which is compiled when installing X-PSI with default settings. Some data files are needed and they can be found in the [Zenodo](https://zenodo.org/record/7094144)."
+    "To run this tutorial, you should install X-PSI with the default (blackbody) atmosphere extension module, which is compiled when installing X-PSI with default settings. \n",
+    "\n",
+    "Some extra data files not available on the GitHub repository are needed to run this tutorial. They can be found in the [Zenodo](https://zenodo.org/record/7094144) and should be placed in the directory `examples/examples_modeling_tutorial/model_data/` of your local xpsi directory.  These are the required files: \n",
+    "- `nicer_v1.01_arf.txt`\n",
+    "- `nicer_v1.01_rmf_matrix.txt`\n",
+    "- `nicer_v1.01_rmf_energymap.txt`"
    ]
   },
   {
@@ -4638,7 +4643,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/examples/examples_fast/Modules/CustomInstrument.py
+++ b/examples/examples_fast/Modules/CustomInstrument.py
@@ -30,14 +30,15 @@ class CustomInstrument(xpsi.Instrument):
         return self._folded_signal
 
     @classmethod
-    def from_response_files(cls, ARF, RMF, max_input, min_input=0,channel=[1,1500],
-                            channel_edges=None):
+    def from_response_files(cls, ARF, RMF, channel_edges,max_input,
+                            min_input=0,channel=[1,1500],
+                            ):
         """ Constructor which converts response files into :class:`numpy.ndarray`s.
         :param str ARF: Path to ARF which is compatible with
                                 :func:`numpy.loadtxt`.
         :param str RMF: Path to RMF which is compatible with
                                 :func:`numpy.loadtxt`.
-        :param str channel_edges: Optional path to edges which is compatible with
+        :param str channel_edges: Path to edges which is compatible with
                                   :func:`numpy.loadtxt`.
         """
 

--- a/examples/examples_fast/Modules/main.py
+++ b/examples/examples_fast/Modules/main.py
@@ -63,10 +63,10 @@ RMF=np.diag(np.full(counter,1))
 
 Instrument = CustomInstrument.from_response_files(ARF =ARF,
                                              RMF = RMF,
+                                             channel_edges =channel_edges,
                                              max_input = 301,
                                              min_input = 10,
-                                             channel=[10,301],
-                                             channel_edges =channel_edges)
+                                             channel=[10,301])
 
 # # Signal
 signal = CustomSignal(data = data,

--- a/examples/examples_modeling_tutorial/TestRun_BB.py
+++ b/examples/examples_modeling_tutorial/TestRun_BB.py
@@ -56,14 +56,15 @@ class CustomInstrument(xpsi.Instrument):
         return self._folded_signal
 
     @classmethod
-    def from_response_files(cls, ARF, RMF, max_input, min_input=0,
-                            channel_edges=None):
+    def from_response_files(cls, ARF, RMF, channel_edges, max_input,
+                            min_input=0,
+                            ):
         """ Constructor which converts response files into :class:`numpy.ndarray`s.
         :param str ARF: Path to ARF which is compatible with
                                 :func:`numpy.loadtxt`.
         :param str RMF: Path to RMF which is compatible with
                                 :func:`numpy.loadtxt`.
-        :param str channel_edges: Optional path to edges which is compatible with
+        :param str channel_edges: Path to edges which is compatible with
                                   :func:`numpy.loadtxt`.
         """
         link ="https://doi.org/10.5281/zenodo.7094144"
@@ -83,12 +84,12 @@ class CustomInstrument(xpsi.Instrument):
         except:
             print("ERROR: You miss the following file: {}\nThe file is found from here: {}".format(RMF, link))
             exit()
-        if channel_edges:
-            try:
-                channel_edges = np.loadtxt(channel_edges, dtype=np.double, skiprows=3)[:,1:]
-            except:
-                print("ERROR: You miss the following file: {}\nThe file is found from here: {}".format(channel_edges, link))
-                exit()
+
+        try:
+            channel_edges = np.loadtxt(channel_edges, dtype=np.double, skiprows=3)[:,1:]
+        except:
+            print("ERROR: You miss the following file: {}\nThe file is found from here: {}".format(channel_edges, link))
+            exit()
 
         matrix = np.ascontiguousarray(RMF[min_input:max_input,20:201].T, dtype=np.double)
 
@@ -106,9 +107,9 @@ class CustomInstrument(xpsi.Instrument):
 
 NICER = CustomInstrument.from_response_files(ARF = 'model_data/nicer_v1.01_arf.txt',
                                              RMF = 'model_data/nicer_v1.01_rmf_matrix.txt',
+                                             channel_edges = 'model_data/nicer_v1.01_rmf_energymap.txt',
                                              max_input = 500,
-                                             min_input = 0,
-                                             channel_edges = 'model_data/nicer_v1.01_rmf_energymap.txt')
+                                             min_input = 0)
 
 bounds = dict(distance = (0.1, 1.0),                     # (Earth) distance
                 mass = (1.0, 3.0),                       # mass

--- a/examples/examples_modeling_tutorial/TestRun_Num.py
+++ b/examples/examples_modeling_tutorial/TestRun_Num.py
@@ -56,14 +56,14 @@ class CustomInstrument(xpsi.Instrument):
         return self._folded_signal
 
     @classmethod
-    def from_response_files(cls, ARF, RMF, max_input, min_input=0,
-                            channel_edges=None):
+    def from_response_files(cls, ARF, RMF, channel_edges, max_input,
+                            min_input=0):
         """ Constructor which converts response files into :class:`numpy.ndarray`s.
         :param str ARF: Path to ARF which is compatible with
                                 :func:`numpy.loadtxt`.
         :param str RMF: Path to RMF which is compatible with
                                 :func:`numpy.loadtxt`.
-        :param str channel_edges: Optional path to edges which is compatible with
+        :param str channel_edges:  Path to edges which is compatible with
                                   :func:`numpy.loadtxt`.
         """
         link ="https://doi.org/10.5281/zenodo.7094144"
@@ -83,12 +83,12 @@ class CustomInstrument(xpsi.Instrument):
         except:
             print("ERROR: You miss the following file: {}\nThe file is found from here: {}".format(RMF, link))
             exit()
-        if channel_edges:
-            try:
-                channel_edges = np.loadtxt(channel_edges, dtype=np.double, skiprows=3)[:,1:]
-            except:
-                print("ERROR: You miss the following file: {}\nThe file is found from here: {}".format(channel_edges, link))
-                exit()
+
+        try:
+            channel_edges = np.loadtxt(channel_edges, dtype=np.double, skiprows=3)[:,1:]
+        except:
+            print("ERROR: You miss the following file: {}\nThe file is found from here: {}".format(channel_edges, link))
+            exit()
 
         matrix = np.ascontiguousarray(RMF[min_input:max_input,20:201].T, dtype=np.double)
 
@@ -106,10 +106,10 @@ class CustomInstrument(xpsi.Instrument):
 
 
 NICER = CustomInstrument.from_response_files(ARF = 'model_data/nicer_v1.01_arf.txt',
-                                     RMF = 'model_data/nicer_v1.01_rmf_matrix.txt',
-                                     max_input = 500,
-                                     min_input = 0,
-                                     channel_edges = 'model_data/nicer_v1.01_rmf_energymap.txt')
+                                             RMF = 'model_data/nicer_v1.01_rmf_matrix.txt',
+                                             channel_edges = 'model_data/nicer_v1.01_rmf_energymap.txt',
+                                             max_input = 500,
+                                             min_input = 0)
 
 bounds = dict(distance = (0.1, 1.0),                     # (Earth) distance
                 mass = (1.0, 3.0),                       # mass

--- a/examples/examples_modeling_tutorial/TestRun_NumBeam.py
+++ b/examples/examples_modeling_tutorial/TestRun_NumBeam.py
@@ -56,14 +56,14 @@ class CustomInstrument(xpsi.Instrument):
         return self._folded_signal
 
     @classmethod
-    def from_response_files(cls, ARF, RMF, max_input, min_input=0,
-                            channel_edges=None):
+    def from_response_files(cls, ARF, RMF, channel_edges, max_input,
+                            min_input=0):
         """ Constructor which converts response files into :class:`numpy.ndarray`s.
         :param str ARF: Path to ARF which is compatible with
                                 :func:`numpy.loadtxt`.
         :param str RMF: Path to RMF which is compatible with
                                 :func:`numpy.loadtxt`.
-        :param str channel_edges: Optional path to edges which is compatible with
+        :param str channel_edges: Path to edges which is compatible with
                                   :func:`numpy.loadtxt`.
         """
         link ="https://doi.org/10.5281/zenodo.7094144"
@@ -83,12 +83,12 @@ class CustomInstrument(xpsi.Instrument):
         except:
             print("ERROR: You miss the following file: {}\nThe file is found from here: {}".format(RMF, link))
             exit()
-        if channel_edges:
-            try:
-                channel_edges = np.loadtxt(channel_edges, dtype=np.double, skiprows=3)[:,1:]
-            except:
-                print("ERROR: You miss the following file: {}\nThe file is found from here: {}".format(channel_edges, link))
-                exit()
+
+        try:
+            channel_edges = np.loadtxt(channel_edges, dtype=np.double, skiprows=3)[:,1:]
+        except:
+            print("ERROR: You miss the following file: {}\nThe file is found from here: {}".format(channel_edges, link))
+            exit()
 
         matrix = np.ascontiguousarray(RMF[min_input:max_input,20:201].T, dtype=np.double)
 
@@ -106,10 +106,10 @@ class CustomInstrument(xpsi.Instrument):
 
 
 NICER = CustomInstrument.from_response_files(ARF = 'model_data/nicer_v1.01_arf.txt',
-                                     RMF = 'model_data/nicer_v1.01_rmf_matrix.txt',
-                                     max_input = 500,
-                                     min_input = 0,
-                                     channel_edges = 'model_data/nicer_v1.01_rmf_energymap.txt')
+                                             RMF = 'model_data/nicer_v1.01_rmf_matrix.txt',
+                                             channel_edges = 'model_data/nicer_v1.01_rmf_energymap.txt',
+                                             max_input = 500,
+                                             min_input = 0)
 
 bounds = dict(distance = (0.1, 1.0),                     # (Earth) distance
                 mass = (1.0, 3.0),                       # mass


### PR DESCRIPTION
All examples and notebooks need `channel_edges` to be a mandatory argument