### PR TITLE
Multiversion docs but by hand

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -16,10 +16,44 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 5
+    - name: Set up GCC
+      run: |
+         sudo apt-get install -y gcc
+      shell: bash -l {0}
+    - name: install gsl
+      run: |
+        sudo apt-get install -y libgsl-dev
 
-    steps:
+    - name: Install Python2 Conda environment with Micromamba
+      uses: mamba-org/provision-with-micromamba@main
+      with:
+        cache-env: true
+        cache-env-key: env-envkey-${{ github.sha }}-${{ github.run_attempt }}
+        environment-file: basic_environment.yml
+        environment-name: xpsipy2
+        extra-specs: |
+          python=2.7
+    - name : install docs dependencies
+      run: |
+        micromamba install sphinx=1.8.5 decorator=4.4.1 h5py 
+        micromamba install -c conda-forge nbsphinx=0.5.1 nbconvert=5.6.1
+        pip install sphinxcontrib-websupport==1.1.2 sphinx_rtd_theme==0.4.3
+    - name: install X-PSI package
+      run: |
+        python setup.py install
+      shell: bash -l {0}
+      env:
+        CC:   gcc-10
+    - name : build docs
+      run: make html
+      working-directory: docs/
+    - name : move docs
+      run : |
+        mkdir docs/build/html/
+        mv docs/build/html/* docs/build/html/py2/
+
     - uses: actions/checkout@v3
-    - name: Install Conda environment with Micromamba
+    - name: Install Python3 Conda environment with Micromamba
       uses: mamba-org/provision-with-micromamba@main
       with:
         cache-env: true
@@ -48,7 +82,7 @@ jobs:
         CC:   gcc-10
     - name : build docs
       run: make html
-      working-directory: docs/
+
     - name: Deploy to GitHub Pages
       if: success()
       uses: crazy-max/ghaction-github-pages@v3

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -23,7 +23,6 @@ jobs:
     - name: install gsl
       run: |
         sudo apt-get install -y libgsl-dev
-
     - name: Install Python2 Conda environment with Micromamba
       uses: mamba-org/provision-with-micromamba@main
       with:
@@ -51,7 +50,6 @@ jobs:
       run : |
         mkdir docs/build/html/
         mv docs/build/html/* docs/build/html/py2/
-
     - uses: actions/checkout@v3
     - name: Install Python3 Conda environment with Micromamba
       uses: mamba-org/provision-with-micromamba@main
@@ -82,7 +80,6 @@ jobs:
         CC:   gcc-10
     - name : build docs
       run: make html
-
     - name: Deploy to GitHub Pages
       if: success()
       uses: crazy-max/ghaction-github-pages@v3

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -16,6 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 5
+
+    steps:
     - name: Set up GCC
       run: |
          sudo apt-get install -y gcc
@@ -23,6 +25,10 @@ jobs:
     - name: install gsl
       run: |
         sudo apt-get install -y libgsl-dev
+    - name: check out X-PSI v1.2.1 
+      uses: actions/checkout@v3
+      with:
+        ref: v1.2.1
     - name: Install Python2 Conda environment with Micromamba
       uses: mamba-org/provision-with-micromamba@main
       with:
@@ -39,7 +45,7 @@ jobs:
         pip install sphinxcontrib-websupport==1.1.2 sphinx_rtd_theme==0.4.3
     - name: install X-PSI package
       run: |
-        python setup.py install
+       python setup.py install
       shell: bash -l {0}
       env:
         CC:   gcc-10
@@ -48,9 +54,14 @@ jobs:
       working-directory: docs/
     - name : move docs
       run : |
-        mkdir docs/build/html/
-        mv docs/build/html/* docs/build/html/py2/
-    - uses: actions/checkout@v3
+        mkdir ../../../../py2
+        mv build/html/* ../../../../py2/
+      working-directory: docs/
+
+    - name: check out X-PSI v1.2.1
+      uses: actions/checkout@v3
+      with:
+        ref: main
     - name: Install Python3 Conda environment with Micromamba
       uses: mamba-org/provision-with-micromamba@main
       with:
@@ -65,13 +76,6 @@ jobs:
         micromamba install sphinx decorator h5py
         micromamba install -c conda-forge nbsphinx nbconvert
         pip install sphinxcontrib-websupport sphinx_rtd_theme
-    - name: Set up GCC
-      run: |
-         sudo apt-get install -y gcc
-      shell: bash -l {0}
-    - name: install gsl
-      run: |
-        sudo apt-get install -y libgsl-dev
     - name: install X-PSI package
       run: |
         python setup.py install
@@ -79,7 +83,12 @@ jobs:
       env:
         CC:   gcc-10
     - name : build docs
-      run: make html
+      run: | 
+        make html
+        mkdir build/html/py2
+        mv ../../../../py2/* build/html/py2/  
+      working-directory: docs/
+
     - name: Deploy to GitHub Pages
       if: success()
       uses: crazy-max/ghaction-github-pages@v3


### PR DESCRIPTION
Fixes #201 in a slightly hacky way by compiling both the Python2 and Python3 documentation by hand. But it works. :)