### PR TITLE
Citation

### DIFF
--- a/docs/source/acknowledgements.rst
+++ b/docs/source/acknowledgements.rst
@@ -84,9 +84,10 @@ Literature
 This project is built upon the work of many researchers in many fields. For
 citations to (astro)physics and (astro)statistics literature, please see the
 technical documents pointed to in the :ref:`citation` section. Moreover, we
-point to the bibliograpy of :ref:`R19` as the first published application of
+point to the bibliograpy of `Riley et al. 2019 <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract>`_ as the first published application of
 the X-PSI package, and to the `ApJL Focus Issue <https://iopscience.iop.org/journal/2041-8205/page/Focus_on_NICER_Constraints_on_the_Dense_Matter_Equation_of_State>`_
-of which this article is a member.
+of which this article is a member. For other scientific papers that have used 
+X-PSI see :ref:`applications`.
 
 
 .. _funding:

--- a/docs/source/applications.rst
+++ b/docs/source/applications.rst
@@ -4,21 +4,20 @@ Applications
 ------------
 
 X-PSI has been applied in the following studies. In addition to giving an
-idea of the scientific applications these may also
-be use useful for rough performance benchmarking and planning 
-of resource consumption.  For the most recent studies see the linked
-papers for full details of settings and resource consumption.
+idea of the scientific applications, these may also
+be useful for performance benchmarking and planning 
+of computational resource consumption. 
 
-If you have used X-PSI for a project would like to link it here, please
+If you have used X-PSI for a project and would like to link it here, please
 contact the X-PSI team and/or submit a pull-request on GitHub.
 
 
 Early X-PSI development
 ***********************
 
-X-PSI was developed by Thomas Riley as part of his PhD thesis work at the University of Amsterdam. 
+X-PSI was initiated by Thomas Riley as part of his PhD work at the University of Amsterdam. 
 Chapter 3 of his `PhD thesis (Riley 2019) <https://hdl.handle.net/11245.1/aa86fcf3-2437-4bc2-810e-cf9f30a98f7a>`_ 
-provides a technical description of ``v0.1`` of X-PSI and contains
+provides an extended technical description of ``v0.1`` of X-PSI and contains
 results of some parameter recovery tests using synthetic data.  
 
 
@@ -27,33 +26,22 @@ NICER papers
 
 X-PSI has been used in several Pulse Profile Modeling analysis papers by the *NICER* team. These are typically published with a Zenodo repository containing data, model files, X-PSI scripts, samples and post-processing notebooks to enable full reproduction and independent analysis. 
 
-**Salmi et al. 2022**
-
-`Salmi et al. 2022 (ApJ, 941, 150) <https://ui.adsabs.harvard.edu/abs/2022ApJ...941..150S/abstract>`_ used  ``v0.7.10`` of X-PSI to model *NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0740+6620 using *NICER* background estimates.  See also the associated `Zenodo repository`__.
+**Salmi et al. 2022** `(ApJ, 941, 150) <https://ui.adsabs.harvard.edu/abs/2022ApJ...941..150S/abstract>`_ used  ``v0.7.10`` of X-PSI to model *NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0740+6620 using *NICER* background estimates.  See also the associated `Zenodo repository`__.
 
 .. _Zenodo22: https://doi.org/10.5281/zenodo.6827536
 __ Zenodo22_
 
 
-**Riley et al. 2021**
-
-`Riley et al. 2021 (ApJL, 918, L27) <https://ui.adsabs.harvard.edu/abs/2021ApJ...918L..27R/abstract>`_ used ``v0.7.6`` of X-PSI to model *NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0740+6620. See also the associated `Zenodo repository`__.
+**Riley et al. 2021**  `(ApJL, 918, L27) <https://ui.adsabs.harvard.edu/abs/2021ApJ...918L..27R/abstract>`_ used ``v0.7.6`` of X-PSI to model *NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0740+6620. See also the associated `Zenodo repository`__.
 
 .. _Zenodo21: https://doi.org/10.5281/zenodo.4697624
 __ Zenodo21_
 
-**Bogdanov et al. 2021**
+**Bogdanov et al. 2021**  `(ApJL, 914, L15) <https://ui.adsabs.harvard.edu/abs/2021ApJ...914L..15B/abstract>`_ provides additional details of the models used for *NICER* Pulse Profile Modeling, reports ray-tracing cross-tests for X-PSI and other codes for very compact stars where multiple imaging is important, and reports some parameter recovery simulations for synthetic data.  
 
-`Bogdanov et al. 2021 (ApJL, 914, L15) <https://ui.adsabs.harvard.edu/abs/2021ApJ...914L..15B/abstract>`_ provides additional details of the models used for *NICER* Pulse Profile Modeling, reports ray-tracing cross-tests for X-PSI and other codes for very compact stars where multiple imaging is important, and reports some parameter recovery simulations for synthetic data.  
+**Bogdanov et al. 2019** `(ApJL, 887, L26) <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..26B/abstract>`_ reports the results of ray-tracing cross-tests for several codes in use in the *NICER* team including X-PSI.
 
-**Bogdanov et al. 2019**
-
-`Bogdanov et al. 2019 (ApJL, 887, L26) <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..26B/abstract.`_ reports the results of ray-tracing cross-tests for several codes in use in the *NICER* team including X-PSI.
-
-
-**Riley et al. 2019**
-
-`Riley et al. 2019 (ApJL, 887, L21) <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract>`_ used 
+**Riley et al. 2019** `(ApJL, 887, L21) <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract>`_ used 
 ``v0.1`` of X-PSI to model *NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0030+0451. 
 See also the associated `Zenodo repository`__.
 
@@ -64,9 +52,7 @@ __ Zenodo_
 Below we give details of some settings for this paper.  For later papers some changes
 were made - see papers for details. 
 
-*Resource consumption*
-
-The calculations reported were performed on the Dutch national supercomputer
+*Resource consumption*:  The calculations reported were performed on the Dutch national supercomputer
 Cartesius, mostly on the *Broadwell* nodes (i.e., using CPUs only, usually
 *Broadwell* architecture).
 A number of models were applied, with increasing complexity.
@@ -74,29 +60,20 @@ Typically, ~1000+ cores were used for posterior sampling, when the
 parallelisation is weighted by time consumed.
 In total, the sampling problems in R19 required ~450,000 core hours.
 
-*Likelihood function settings*
-
-On compute nodes, the likelihood function evaluation times ranged from ~1 to
+*Likelihood function settings*:  On compute nodes, the likelihood function evaluation times ranged from ~1 to
 ~3 seconds (single-threaded), depending on the model and point in parameter
 space.\ [#]_ The parallelisation was purely via MPI, with all but one process
 receiving likelihood function evaluation requests.
 
-*Resolution settings*
+*Resolution settings*: Number of surface cells/elements per hot (closed) region:\ [#]_ 24x24; 
+Number of phases (linearly spaced) = 100; Number of energies (logarithmically spaced) = 175; 
+Number of rays (per parallel; linear in cosine of ray angle alpha):\ [#]_ 200
 
-+ number of surface cells/elements per hot (closed) region:\ [#]_ 24x24
-+ number of phases (linearly spaced): 100
-+ number of energies (logarithmically spaced): 175
-+ number of rays (per parallel; linear in cosine of ray angle alpha):\ [#]_ 200
-
-*Interpolation settings*
-
-+ Steffen splines (GSL) were used everywhere apart from for the atmosphere
-+ for the atmosphere cubic polynomial interpolants were used in four dimensions
+*Interpolation settings*:  Steffen splines (GSL) were used everywhere apart from for the atmosphere, and 
+for the atmosphere cubic polynomial interpolants were used in four dimensions.
 
 
-*Compilation*
-
-Intel compiler collection,\ [#]_ with the CORE-AVX2 instruction set, for X-PSI
+*Compilation*:  Intel compiler collection,\ [#]_ with the CORE-AVX2 instruction set, for X-PSI
 and dependencies (apart from :mod:`numpy`, which was centrally installed).
 
 

--- a/docs/source/applications.rst
+++ b/docs/source/applications.rst
@@ -3,81 +3,68 @@
 Applications
 ------------
 
-X-PSI was applied in the following studies, most recent listed first. 
-These may be useful for rough performance benchmarking and planning 
+X-PSI has been applied in the following studies. In addition to giving an
+idea of the scientific applications these may also
+be use useful for rough performance benchmarking and planning 
 of resource consumption.  For the most recent studies see the linked
 papers for full details of settings and resource consumption.
 
-If you have used X-PSI for a project and have time to summarise it here, please
+If you have used X-PSI for a project would like to link it here, please
 contact the X-PSI team and/or submit a pull-request on GitHub.
 
-.. _S22:
 
-`Salmi et al. 2022 (ApJ, 941 150)`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Early X-PSI development
+***********************
 
-.. _ADS22: https://ui.adsabs.harvard.edu/abs/2022ApJ...941..150S/abstract
+X-PSI was developed by Thomas Riley as part of his PhD thesis work at the University of Amsterdam. 
+Chapter 3 of his `PhD thesis (Riley 2019) <https://hdl.handle.net/11245.1/aa86fcf3-2437-4bc2-810e-cf9f30a98f7a>`_ 
+provides a technical description of ``v0.1`` of X-PSI and contains
+results of some parameter recovery tests using synthetic data.  
 
-__ ADS22_
 
-`Salmi et al. (2022; hereafter S22)`__ used ``v0.7.10`` of X-PSI to model
-*NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0740+6620 using *NICER*
-background estimates.
+NICER papers
+************
 
-__ ADS22_
+X-PSI has been used in several Pulse Profile Modeling analysis papers by the *NICER* team. These are typically published with a Zenodo repository containing data, model files, X-PSI scripts, samples and post-processing notebooks to enable full reproduction and independent analysis. 
 
-See also the associated `Zenodo repository`__.
+**Salmi et al. 2022**
+
+`Salmi et al. 2022 (ApJ, 941, 150) <https://ui.adsabs.harvard.edu/abs/2022ApJ...941..150S/abstract>`_ used  ``v0.7.10`` of X-PSI to model *NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0740+6620 using *NICER* background estimates.  See also the associated `Zenodo repository`__.
 
 .. _Zenodo22: https://doi.org/10.5281/zenodo.6827536
 __ Zenodo22_
 
 
-.. _R21:
+**Riley et al. 2021**
 
-`Riley et al. 2021 (ApJL, 918, L27)`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. _ADS21: https://ui.adsabs.harvard.edu/abs/2021ApJ...918L..27R/abstract
-
-__ ADS21_
-
-`Riley et al. (2021; hereafter R21)`__ used ``v0.7.6`` of X-PSI to model
-*NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0740+6620.
-
-__ ADS21_
-
-See also the associated `Zenodo repository`__.
+`Riley et al. 2021 (ApJL, 918, L27) <https://ui.adsabs.harvard.edu/abs/2021ApJ...918L..27R/abstract>`_ used ``v0.7.6`` of X-PSI to model *NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0740+6620. See also the associated `Zenodo repository`__.
 
 .. _Zenodo21: https://doi.org/10.5281/zenodo.4697624
 __ Zenodo21_
 
+**Bogdanov et al. 2021**
+
+`Bogdanov et al. 2021 (ApJL, 914, L15) <https://ui.adsabs.harvard.edu/abs/2021ApJ...914L..15B/abstract>`_ provides additional details of the models used for *NICER* Pulse Profile Modeling, reports ray-tracing cross-tests for X-PSI and other codes for very compact stars where multiple imaging is important, and reports some parameter recovery simulations for synthetic data.  
+
+**Bogdanov et al. 2019**
+
+`Bogdanov et al. 2019 (ApJL, 887, L26) <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..26B/abstract.`_ reports the results of ray-tracing cross-tests for several codes in use in the *NICER* team including X-PSI.
 
 
-.. _R19:
+**Riley et al. 2019**
 
-`Riley et al. 2019 (ApJL, 887, L21)`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. _ADS: https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract
-
-__ ADS_
-
-`Riley et al. (2019; hereafter R19)`__ used ``v0.1`` of X-PSI to model
-*NICER* observations of the rotation-powered millisecond X-ray pulsar
-PSR J0030+0451.
-
-__ ADS_
-
+`Riley et al. 2019 (ApJL, 887, L21) <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract>`_ used 
+``v0.1`` of X-PSI to model *NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0030+0451. 
 See also the associated `Zenodo repository`__.
 
 .. _Zenodo: https://doi.org/10.5281/zenodo.3386448
 
 __ Zenodo_
 
-Below we give details of some settings for R19.  For later papers some changes
+Below we give details of some settings for this paper.  For later papers some changes
 were made - see papers for details. 
 
-**Resource consumption**
+*Resource consumption*
 
 The calculations reported were performed on the Dutch national supercomputer
 Cartesius, mostly on the *Broadwell* nodes (i.e., using CPUs only, usually
@@ -87,7 +74,7 @@ Typically, ~1000+ cores were used for posterior sampling, when the
 parallelisation is weighted by time consumed.
 In total, the sampling problems in R19 required ~450,000 core hours.
 
-**Likelihood function settings**
+*Likelihood function settings*
 
 On compute nodes, the likelihood function evaluation times ranged from ~1 to
 ~3 seconds (single-threaded), depending on the model and point in parameter
@@ -107,7 +94,7 @@ receiving likelihood function evaluation requests.
 + for the atmosphere cubic polynomial interpolants were used in four dimensions
 
 
-**Compilation**
+*Compilation*
 
 Intel compiler collection,\ [#]_ with the CORE-AVX2 instruction set, for X-PSI
 and dependencies (apart from :mod:`numpy`, which was centrally installed).

--- a/docs/source/citation.rst
+++ b/docs/source/citation.rst
@@ -3,7 +3,6 @@
 Citation
 --------
 
-
 If X-PSI proves to be a useful tool for your work, please cite the project
 as a software acknowledgement, e.g.:
 
@@ -11,121 +10,40 @@ as a software acknowledgement, e.g.:
 
     X-PSI (\url{https://github.com/xpsi-group/xpsi.git}, \citet{xpsi})
 
-    @MISC{xpsi,
-        author = {{Riley}, Thomas Edward},
-        title = "{X-PSI: X-ray Pulse Simulation and Inference}",
-        keywords = {Software},
-        year = 2021,
-        month = feb,
-        eid = {ascl:2102.005},
-        pages = {ascl:2102.005},
-        archivePrefix = {ascl},
-        eprint = {2102.005},
-        adsurl = {https://ui.adsabs.harvard.edu/abs/2021ascl.soft02005R},
-        adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-    }
-
-A JOSS paper has been submitted to accompany the v1.0 release, and will eventually
-be the default paper to cite.  In the mean time some of the technical notes on
-X-PSI can be found in Chapter 3 of Thomas Riley's PhD thesis, which may also
-be cited.  
+and cite the X-PSI Journal of Open Source Software (JOSS) paper:
 
 .. code-block:: latex
 
-   @phdthesis{riley19,
-       author = {{Riley}, Thomas E.},
-       title = "{Neutron star parameter estimation from a NICER perspective}",
-       school = {University of Amsterdam},
-       year = 2019,
-       address = {https://hdl.handle.net/11245.1/aa86fcf3-2437-4bc2-810e-cf9f30a98f7a},
-       month = 12
-   }
-
-If you wish to point to the first published applications of the X-PSI package,
-then please cite :ref:`R19` and :ref:`R21`:
-
-.. code-block:: latex
-
-    @article{riley19,
-        author = {{Riley}, T.~E. and {Watts}, A.~L.
-                                 and {Bogdanov}, S.
-                                 and {Ray}, P.~S.
-                                 and {Ludlam}, R.~M.
-                                 and {Guillot}, S.
-                                 and {Arzoumanian}, Z.
-                                 and {Baker}, C.~L.
-                                 and {Bilous}, A.~V.
-                                 and {Chakrabarty}, D.
-                                 and {Gendreau}, K.~C.
-                                 and {Harding}, A.~K.
-                                 and {Ho}, W.~C.~G.
-                                 and {Lattimer}, J.~M.
-                                 and {Morsink}, S.~M.
-                                 and {Strohmayer}, T.~E.},
-        title = "{A NICER View of PSR J0030+0451: Millisecond Pulsar Parameter Estimation}",
-        doi = {10.3847/2041-8213/ab481c},
-        journal = {\apjl},
-        month = dec,
-        year = 2019,
-        volume = 887,
-        pages = {L21}
-    }
-
-    @article{riley21,
-	author = {{Riley}, Thomas E. 	and {Watts}, Anna L. 
-					and {Ray}, Paul S. 
-					and {Bogdanov}, Slavko 
-					and {Guillot}, Sebastien 
-					and {Morsink}, Sharon M. 
-					and {Bilous}, Anna V. 
-					and {Arzoumanian}, Zaven 
-					and {Choudhury}, Devarshi 
-					and {Deneva}, Julia S. 
-					and {Gendreau}, Keith C. 
-					and {Harding}, Alice K. 
-					and {Ho}, Wynn C.~G. 
-					and {Lattimer}, James M. 
-					and {Loewenstein}, Michael 
-					and {Ludlam}, Renee M. 
-					and {Markwardt}, Craig B. 
-					and {Okajima}, Takashi 
-					and {Prescod-Weinstein}, Chanda 
-					and {Remillard}, Ronald A. 
-					and {Wolff}, Michael T. 
-					and {Fonseca}, Emmanuel 
-					and {Cromartie}, H. Thankful 
-					and {Kerr}, Matthew 
-					and {Pennucci}, Timothy T. 
-					and {Parthasarathy}, Aditya 
-					and {Ransom}, Scott 
-					and {Stairs}, Ingrid 
-					and {Guillemot}, Lucas 
-					and {Cognard}, Ismael},
-        title = "{A NICER View of the Massive Pulsar PSR J0740+6620 Informed by Radio Timing and XMM-Newton Spectroscopy}",
-        journal = {\apjl},
-        year = 2021,
-        month = sep,
-        volume = {918},
-        number = {2},
-        pages = {L27},
-        doi = {10.3847/2041-8213/ac0a81}
-    }
+	@ARTICLE{xpsi,
+       	author = {{Riley}, Thomas E. 	and {Choudhury}, Devarshi 
+				     	and {Salmi}, Tuomo 
+     					and {Vinciguerra}, Serena 
+					and {Kini}, Yves 
+					and {Dorsman}, Bas 
+					and {Watts}, Anna L. 
+					and {Huppenkothen}, D. 
+					and {Guillot}, Sebastien },
+        title = "{X-PSI: A Python package for neutron star X-ray Pulse Simulation and Inference}",
+        journal = "{Journal of Open Source Software}",
+     	keywords = {Software},
+        year = 2023,
+       	doi  = {}
+	url = {}
+	}
 
 
-This article contains a wealth of relevant information, including a number
-of schematic diagrams that might be of use. There is also an
-`ApJL Focus Issue <https://iopscience.iop.org/journal/2041-8205/page/Focus_on_NICER_Constraints_on_the_Dense_Matter_Equation_of_State>`_
-of which this article is a member.
+If you wish to cite published applications of the X-PSI package you can find a list of papers
+that have used the software via :ref:`Applications`. 
 
-Regardless of whether you cite the above articles, they critically demonstrate
-how to cite the numerous X-PSI dependencies that users of X-PSI benefit
-from. These citations may be found in the software acknowledgements and in the
+X-PSI has numerous dependencies that users also benefit from.
+Citations to these packages may be found in the software acknowledgements of both the X-PSI 
+JOSS paper and our :ref:`Applications` papers, and in the
 article text where the relevant software is applied. Links to the software and
 associated preprints and journal articles may be found in the bibliographies.
-Please follow the guidelines demonstrated in :ref:`R19` and :ref:`R21`
+Please follow the guidelines demonstrated in e.g. Riley et al. (2021)
 to ensure the authors of the software receive the recognition they should.
 The dependencies often have their own citation instructions that should be
-followed first and foremost, but as an example from :ref:`R21`. 
+followed first and foremost, but as an example from Riley et al. (2021). 
 
 .. code-block:: latex
 

--- a/docs/source/citation.rst
+++ b/docs/source/citation.rst
@@ -40,10 +40,10 @@ Citations to these packages may be found in the software acknowledgements of bot
 JOSS paper and our :ref:`Applications` papers, and in the
 article text where the relevant software is applied. Links to the software and
 associated preprints and journal articles may be found in the bibliographies.
-Please follow the guidelines demonstrated in e.g. Riley et al. (2021)
+Please follow the guidelines demonstrated in e.g. `Riley et al. 2021 <https://ui.adsabs.harvard.edu/abs/2021ApJ...918L..27R/abstract>`_
 to ensure the authors of the software receive the recognition they should.
 The dependencies often have their own citation instructions that should be
-followed first and foremost, but as an example from Riley et al. (2021). 
+followed first and foremost, but as an example from `Riley et al. 2021 <https://ui.adsabs.harvard.edu/abs/2021ApJ...918L..27R/abstract>`_. 
 
 .. code-block:: latex
 


### PR DESCRIPTION
Major changes to Citation and Applications pages, small correction to Team+Acknowledgements pages.  Addresses #247 

Note:  cross references to Riley et al. 2019/2021 are now gone and this may require some hyperlinks to be updated in other documentation pages when we do a full sweep.  