### PR TITLE
General py2 documents update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -519,7 +519,7 @@ Added
 
 * An extension module for calculating hot region local variables from global
   variables for hot region configurations under the umbrella of the PST-U model
-  introduced in :ref:`R19`.
+  introduced in `Riley et al. (2019) <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract>`_.
 
 Attribution
 ^^^^^^^^^^^
@@ -981,7 +981,7 @@ Summary
   complex plotting routines can thus be developed, as demonstrated in the
   concrete classes such as :class:`xpsi.PostProcessing.PulsePlot`. The plot
   classes have been used to reproduce (with improved functionality and
-  performance) the relevant signal plots from :ref:`R19`, as demonstrated
+  performance) the relevant signal plots from `Riley et al. (2019) <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract>`_, as demonstrated
   in the post-processing tutorial notebook and embedded in the class docstrings
   for reference.
 * Development of online documentation pages, including project organisation

--- a/docs/source/FAQ.rst
+++ b/docs/source/FAQ.rst
@@ -54,7 +54,7 @@ for each of the Python processes running on one node.
 That table is pointed to for access where needed from compiled modules
 (C extensions to Python): it is not loaded from disk per likelihood call.
 We provide an example custom Python class that handles this loading (as used
-in :ref:`R19`, hereafter R19).
+in `Riley et al. 2019 <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract>`_, hereafter R19).
 
 Disk storage required is indeed small: up to :math:`\mathcal{O}(100)` Mbytes for
 applications thus far (e.g., R19). There is a variant of MultiNest nested sampling

--- a/docs/source/acknowledgements.rst
+++ b/docs/source/acknowledgements.rst
@@ -43,8 +43,10 @@ Folks who have used X-PSI in their research or engaged with the team during
 development and science analysis, thereby prompting fixes or
 improvements.
 
+* Matteo Bacchetti
 * Anna Bilous
 * Erik Bootsma
+* Johannes Buchner
 * Yuri Cavecchi
 * Frank Chambers
 * Alex Chen
@@ -53,6 +55,7 @@ improvements.
 * Gwénaël Loyer
 * Geert Raaijmakers
 * Paul Ray
+* Evert Rol
 * Rahul Silié
 * Emma van der Wateren
 * Bob de Witte
@@ -81,9 +84,10 @@ Literature
 This project is built upon the work of many researchers in many fields. For
 citations to (astro)physics and (astro)statistics literature, please see the
 technical documents pointed to in the :ref:`citation` section. Moreover, we
-point to the bibliograpy of :ref:`R19` as the first published application of
+point to the bibliograpy of `Riley et al. 2019 <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract>`_ as the first published application of
 the X-PSI package, and to the `ApJL Focus Issue <https://iopscience.iop.org/journal/2041-8205/page/Focus_on_NICER_Constraints_on_the_Dense_Matter_Equation_of_State>`_
-of which this article is a member.
+of which this article is a member. For other scientific papers that have used 
+X-PSI see :ref:`applications`.
 
 
 .. _funding:

--- a/docs/source/applications.rst
+++ b/docs/source/applications.rst
@@ -3,83 +3,56 @@
 Applications
 ------------
 
-X-PSI was applied in the following studies, most recent listed first. 
-These may be useful for rough performance benchmarking and planning 
-of resource consumption.  For the most recent studies see the linked
-papers for full details of settings and resource consumption.
+X-PSI has been applied in the following studies. In addition to giving an
+idea of the scientific applications, these may also
+be useful for performance benchmarking and planning 
+of computational resource consumption. 
 
-If you have used X-PSI for a project and have time to summarise it here, please
+If you have used X-PSI for a project and would like to link it here, please
 contact the X-PSI team and/or submit a pull-request on GitHub.
 
-.. _S22:
 
-`Salmi et al. 2022 (ApJ in press)`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Early X-PSI development
+***********************
 
-.. _ADS22: https://ui.adsabs.harvard.edu/abs/2022arXiv220912840S/abstract
+X-PSI was initiated by Thomas Riley as part of his PhD work at the University of Amsterdam. 
+Chapter 3 of his `PhD thesis (Riley 2019) <https://hdl.handle.net/11245.1/aa86fcf3-2437-4bc2-810e-cf9f30a98f7a>`_ 
+provides an extended technical description of ``v0.1`` of X-PSI and contains
+results of some parameter recovery tests using synthetic data.  
 
-__ ADS22_
 
-`Salmi et al. (2022; hereafter S22)`__ used ``v0.7.10`` of X-PSI to model
-*NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0740+6620 using *NICER*
-background estimates.
+NICER papers
+************
 
-__ ADS22_
+X-PSI has been used in several Pulse Profile Modeling analysis papers by the *NICER* team. These are typically published with a Zenodo repository containing data, model files, X-PSI scripts, samples and post-processing notebooks to enable full reproduction and independent analysis. 
 
-See also the associated `Zenodo repository`__.
+**Salmi et al. 2022** `(ApJ, 941, 150) <https://ui.adsabs.harvard.edu/abs/2022ApJ...941..150S/abstract>`_ used  ``v0.7.10`` of X-PSI to model *NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0740+6620 using *NICER* background estimates.  See also the associated `Zenodo repository`__.
 
 .. _Zenodo22: https://doi.org/10.5281/zenodo.6827536
 __ Zenodo22_
 
 
-.. _R21:
-
-`Riley et al. 2021 (ApJL, 918, L27)`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. _ADS21: https://ui.adsabs.harvard.edu/abs/2021ApJ...918L..27R/abstract
-
-__ ADS21_
-
-`Riley et al. (2021; hereafter R21)`__ used ``v0.7.6`` of X-PSI to model
-*NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0740+6620.
-
-__ ADS21_
-
-See also the associated `Zenodo repository`__.
+**Riley et al. 2021**  `(ApJL, 918, L27) <https://ui.adsabs.harvard.edu/abs/2021ApJ...918L..27R/abstract>`_ used ``v0.7.6`` of X-PSI to model *NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0740+6620. See also the associated `Zenodo repository`__.
 
 .. _Zenodo21: https://doi.org/10.5281/zenodo.4697624
 __ Zenodo21_
 
+**Bogdanov et al. 2021**  `(ApJL, 914, L15) <https://ui.adsabs.harvard.edu/abs/2021ApJ...914L..15B/abstract>`_ provides additional details of the models used for *NICER* Pulse Profile Modeling, reports ray-tracing cross-tests for X-PSI and other codes for very compact stars where multiple imaging is important, and reports some parameter recovery simulations for synthetic data.  
 
+**Bogdanov et al. 2019** `(ApJL, 887, L26) <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..26B/abstract>`_ reports the results of ray-tracing cross-tests for several codes in use in the *NICER* team including X-PSI.
 
-.. _R19:
-
-`Riley et al. 2019 (ApJL, 887, L21)`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. _ADS: https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract
-
-__ ADS_
-
-`Riley et al. (2019; hereafter R19)`__ used ``v0.1`` of X-PSI to model
-*NICER* observations of the rotation-powered millisecond X-ray pulsar
-PSR J0030+0451.
-
-__ ADS_
-
+**Riley et al. 2019** `(ApJL, 887, L21) <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract>`_ used 
+``v0.1`` of X-PSI to model *NICER* observations of the rotation-powered millisecond X-ray pulsar PSR J0030+0451. 
 See also the associated `Zenodo repository`__.
 
 .. _Zenodo: https://doi.org/10.5281/zenodo.3386448
 
 __ Zenodo_
 
-Below we give details of some settings for R19.  For later papers some changes
+Below we give details of some settings for this paper.  For later papers some changes
 were made - see papers for details. 
 
-**Resource consumption**
-
-The calculations reported were performed on the Dutch national supercomputer
+*Resource consumption*:  The calculations reported were performed on the Dutch national supercomputer
 Cartesius, mostly on the *Broadwell* nodes (i.e., using CPUs only, usually
 *Broadwell* architecture).
 A number of models were applied, with increasing complexity.
@@ -87,29 +60,20 @@ Typically, ~1000+ cores were used for posterior sampling, when the
 parallelisation is weighted by time consumed.
 In total, the sampling problems in R19 required ~450,000 core hours.
 
-**Likelihood function settings**
-
-On compute nodes, the likelihood function evaluation times ranged from ~1 to
+*Likelihood function settings*:  On compute nodes, the likelihood function evaluation times ranged from ~1 to
 ~3 seconds (single-threaded), depending on the model and point in parameter
 space.\ [#]_ The parallelisation was purely via MPI, with all but one process
 receiving likelihood function evaluation requests.
 
-*Resolution settings*
+*Resolution settings*: Number of surface cells/elements per hot (closed) region:\ [#]_ 24x24; 
+Number of phases (linearly spaced) = 100; Number of energies (logarithmically spaced) = 175; 
+Number of rays (per parallel; linear in cosine of ray angle alpha):\ [#]_ 200
 
-+ number of surface cells/elements per hot (closed) region:\ [#]_ 24x24
-+ number of phases (linearly spaced): 100
-+ number of energies (logarithmically spaced): 175
-+ number of rays (per parallel; linear in cosine of ray angle alpha):\ [#]_ 200
-
-*Interpolation settings*
-
-+ Steffen splines (GSL) were used everywhere apart from for the atmosphere
-+ for the atmosphere cubic polynomial interpolants were used in four dimensions
+*Interpolation settings*:  Steffen splines (GSL) were used everywhere apart from for the atmosphere, and 
+for the atmosphere cubic polynomial interpolants were used in four dimensions.
 
 
-**Compilation**
-
-Intel compiler collection,\ [#]_ with the CORE-AVX2 instruction set, for X-PSI
+*Compilation*:  Intel compiler collection,\ [#]_ with the CORE-AVX2 instruction set, for X-PSI
 and dependencies (apart from :mod:`numpy`, which was centrally installed).
 
 

--- a/docs/source/citation.rst
+++ b/docs/source/citation.rst
@@ -3,7 +3,6 @@
 Citation
 --------
 
-
 If X-PSI proves to be a useful tool for your work, please cite the project
 as a software acknowledgement, e.g.:
 
@@ -11,121 +10,40 @@ as a software acknowledgement, e.g.:
 
     X-PSI (\url{https://github.com/xpsi-group/xpsi.git}, \citet{xpsi})
 
-    @MISC{xpsi,
-        author = {{Riley}, Thomas Edward},
-        title = "{X-PSI: X-ray Pulse Simulation and Inference}",
-        keywords = {Software},
-        year = 2021,
-        month = feb,
-        eid = {ascl:2102.005},
-        pages = {ascl:2102.005},
-        archivePrefix = {ascl},
-        eprint = {2102.005},
-        adsurl = {https://ui.adsabs.harvard.edu/abs/2021ascl.soft02005R},
-        adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-    }
-
-A JOSS paper has been submitted to accompany the v1.0 release, and will eventually
-be the default paper to cite.  In the mean time some of the technical notes on
-X-PSI can be found in Chapter 3 of Thomas Riley's PhD thesis, which may also
-be cited.  
+and cite the X-PSI Journal of Open Source Software (JOSS) paper:
 
 .. code-block:: latex
 
-   @phdthesis{riley19,
-       author = {{Riley}, Thomas E.},
-       title = "{Neutron star parameter estimation from a NICER perspective}",
-       school = {University of Amsterdam},
-       year = 2019,
-       address = {https://hdl.handle.net/11245.1/aa86fcf3-2437-4bc2-810e-cf9f30a98f7a},
-       month = 12
-   }
-
-If you wish to point to the first published applications of the X-PSI package,
-then please cite :ref:`R19` and :ref:`R21`:
-
-.. code-block:: latex
-
-    @article{riley19,
-        author = {{Riley}, T.~E. and {Watts}, A.~L.
-                                 and {Bogdanov}, S.
-                                 and {Ray}, P.~S.
-                                 and {Ludlam}, R.~M.
-                                 and {Guillot}, S.
-                                 and {Arzoumanian}, Z.
-                                 and {Baker}, C.~L.
-                                 and {Bilous}, A.~V.
-                                 and {Chakrabarty}, D.
-                                 and {Gendreau}, K.~C.
-                                 and {Harding}, A.~K.
-                                 and {Ho}, W.~C.~G.
-                                 and {Lattimer}, J.~M.
-                                 and {Morsink}, S.~M.
-                                 and {Strohmayer}, T.~E.},
-        title = "{A NICER View of PSR J0030+0451: Millisecond Pulsar Parameter Estimation}",
-        doi = {10.3847/2041-8213/ab481c},
-        journal = {\apjl},
-        month = dec,
-        year = 2019,
-        volume = 887,
-        pages = {L21}
-    }
-
-    @article{riley21,
-	author = {{Riley}, Thomas E. 	and {Watts}, Anna L. 
-					and {Ray}, Paul S. 
-					and {Bogdanov}, Slavko 
-					and {Guillot}, Sebastien 
-					and {Morsink}, Sharon M. 
-					and {Bilous}, Anna V. 
-					and {Arzoumanian}, Zaven 
-					and {Choudhury}, Devarshi 
-					and {Deneva}, Julia S. 
-					and {Gendreau}, Keith C. 
-					and {Harding}, Alice K. 
-					and {Ho}, Wynn C.~G. 
-					and {Lattimer}, James M. 
-					and {Loewenstein}, Michael 
-					and {Ludlam}, Renee M. 
-					and {Markwardt}, Craig B. 
-					and {Okajima}, Takashi 
-					and {Prescod-Weinstein}, Chanda 
-					and {Remillard}, Ronald A. 
-					and {Wolff}, Michael T. 
-					and {Fonseca}, Emmanuel 
-					and {Cromartie}, H. Thankful 
-					and {Kerr}, Matthew 
-					and {Pennucci}, Timothy T. 
-					and {Parthasarathy}, Aditya 
-					and {Ransom}, Scott 
-					and {Stairs}, Ingrid 
-					and {Guillemot}, Lucas 
-					and {Cognard}, Ismael},
-        title = "{A NICER View of the Massive Pulsar PSR J0740+6620 Informed by Radio Timing and XMM-Newton Spectroscopy}",
-        journal = {\apjl},
-        year = 2021,
-        month = sep,
-        volume = {918},
-        number = {2},
-        pages = {L27},
-        doi = {10.3847/2041-8213/ac0a81}
-    }
+	@ARTICLE{xpsi,
+       	author = {{Riley}, Thomas E. 	and {Choudhury}, Devarshi 
+				     	and {Salmi}, Tuomo 
+     					and {Vinciguerra}, Serena 
+					and {Kini}, Yves 
+					and {Dorsman}, Bas 
+					and {Watts}, Anna L. 
+					and {Huppenkothen}, D. 
+					and {Guillot}, Sebastien },
+        title = "{X-PSI: A Python package for neutron star X-ray Pulse Simulation and Inference}",
+        journal = "{Journal of Open Source Software}",
+     	keywords = {Software},
+        year = 2023,
+       	doi  = {}
+	url = {}
+	}
 
 
-This article contains a wealth of relevant information, including a number
-of schematic diagrams that might be of use. There is also an
-`ApJL Focus Issue <https://iopscience.iop.org/journal/2041-8205/page/Focus_on_NICER_Constraints_on_the_Dense_Matter_Equation_of_State>`_
-of which this article is a member.
+If you wish to cite published applications of the X-PSI package you can find a list of papers
+that have used the software via :ref:`Applications`. 
 
-Regardless of whether you cite the above articles, they critically demonstrate
-how to cite the numerous X-PSI dependencies that users of X-PSI benefit
-from. These citations may be found in the software acknowledgements and in the
+X-PSI has numerous dependencies that users also benefit from.
+Citations to these packages may be found in the software acknowledgements of both the X-PSI 
+JOSS paper and our :ref:`Applications` papers, and in the
 article text where the relevant software is applied. Links to the software and
 associated preprints and journal articles may be found in the bibliographies.
-Please follow the guidelines demonstrated in :ref:`R19` and :ref:`R21`
+Please follow the guidelines demonstrated in e.g. `Riley et al. 2021 <https://ui.adsabs.harvard.edu/abs/2021ApJ...918L..27R/abstract>`_
 to ensure the authors of the software receive the recognition they should.
 The dependencies often have their own citation instructions that should be
-followed first and foremost, but as an example from :ref:`R21`. 
+followed first and foremost, but as an example from `Riley et al. 2021 <https://ui.adsabs.harvard.edu/abs/2021ApJ...918L..27R/abstract>`_. 
 
 .. code-block:: latex
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -171,7 +171,7 @@ ensemble-MCMC is optional.
 .. rubric:: Footnotes
 
 .. [#] The version of GetDist_ currently compatible with X-PSI, and used in
-       :ref:`R19`, is v0.3.1. It may be cloned as follows:
+       `Riley et al. (2019) <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract>`_, is v0.3.1. It may be cloned as follows:
 
        .. code-block:: bash
 
@@ -179,7 +179,8 @@ ensemble-MCMC is optional.
           https://github.com/ThomasEdwardRiley/getdist.git
 
 .. [#] The version of nestcheck_ currently compatible with X-PSI, and used in
-       :ref:`R19`, is v0.2.0. It may be cloned as follows:
+       `Riley et al. (2019) <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract>`_, is v0.2.0. 
+        It may be cloned as follows:
 
        .. code-block:: bash
 
@@ -310,7 +311,7 @@ The package will be installed in your Conda environment (if activated).
 
 .. note::
 
-    Here we clone the PyMultiNest repository. However, for :ref:`R19`,
+    Here we clone the PyMultiNest repository. However, for `Riley et al. (2019) <https://ui.adsabs.harvard.edu/abs/2019ApJ...887L..21R/abstract>`_,
     working with X-PSI ``v0.1``, we used the repository as frozen in a *fork*.
     To clone this version instead:
 

--- a/docs/source/todo.rst
+++ b/docs/source/todo.rst
@@ -4,5 +4,5 @@ Future
 ------
 
 All good things come to an end and sadly there is no future for the Python 2 variant
-of X-PSI.  Please return to the main X-PSI page and switch to the Python 3 (X-PSI v>2.0)
-variant and see what the future holds! 
+of X-PSI.  Please return to the `main X-PSI page <https://xpsi-group.github.io/xpsi/>`_
+ and switch to the Python 3 (X-PSI v>2.0) variant to see what the future holds! 

--- a/docs/source/todo.rst
+++ b/docs/source/todo.rst
@@ -3,16 +3,6 @@
 Future
 ------
 
-If there is a feature you would like to see that is not currently
-implemented in the package please let us know!
-
-We are currently working on the following upgrades:
-
-* Moving to Python 3 from Python 2 (next major X-PSI release)
-* Providing examples for importance sampling
-* Documenting new post-processing features and improved visualisation tools.
-* Additional features to support parameter recovery tests
-* New atmosphere extension modules
-* Support for X-ray polarimetry 
-* Automatic module generator
-
+All good things come to an end and sadly there is no future for the Python 2 variant
+of X-PSI.  Please return to the main X-PSI page and switch to the Python 3 (X-PSI v>2.0)
+variant and see what the future holds! 


### PR DESCRIPTION
Updates to Citation, Team & Acknowledgements, Applications pages.

Update to Future page (for py2, to point out that it has none).

Note:  will break some cross-references to papers (R19, R21 references) in the py2 documentation.  Not fatal but may fix this at a later date.