### PR TITLE
Use python2 branch to compile docs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -28,7 +28,7 @@ jobs:
     - name: check out X-PSI v1.2.1 
       uses: actions/checkout@v3
       with:
-        ref: v1.2.1
+        ref: python2
     - name: Install Python2 Conda environment with Micromamba
       uses: mamba-org/provision-with-micromamba@main
       with:


### PR DESCRIPTION
The python2 branch has all the relevant changes, so we should use that one to build docs.