### PR TITLE
`np.int` changed to `np.int32`

### DIFF
--- a/xpsi/Data.py
+++ b/xpsi/Data.py
@@ -212,7 +212,7 @@ class Data(object):
                               channel_edges=None,
                               skiprows=1,
                               eV=False,
-                              dtype=_np.int,
+                              dtype=_np.int32,
                               *args, **kwargs):
         """ Load a phase-folded event list and bin the events in phase.
 


### PR DESCRIPTION
that one must have fallen through the cracks of py2 -> py3