### PR TITLE
Fix 1 line for instructions to install on Snellius

### DIFF
--- a/docs/source/HPC_systems.rst
+++ b/docs/source/HPC_systems.rst
@@ -78,7 +78,7 @@ Load ``cmake`` module:
 
 .. code-block:: bash
 
-    module load CMake/3.20.1-GCCcore-10.3.0
+    module load CMake/3.23.1-GCCcore-11.3.0
 
 To prepare MPI from ``$HOME``:
 


### PR DESCRIPTION
from 
3.20.1-GCCcore-10.3.0 
to
3.23.1-GCCcore-11.3.0