### PR TITLE
Postprocessing figure adjustments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,7 @@ and this project adheres to
 .. ^^^^^^^^^^^
 
 
-[pre-v2.0.3] - 2023-06-09
+[pre-v2.0.3] - 2023-07-04
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Summary
@@ -52,6 +52,8 @@ Added
 * Added a keyword argument in ``xpsi/PostProcessing/_corner.py`` to allow user to define the decimal precisions for all the credible intervals printed in the figures (T.S.).
 
 * Added a photosphere setter in ``xpsi/Star.py`` which should allow producing residual and signal plots for models with multiple photosphere objects as explained in ``https://github.com/xpsi-group/xpsi/issues/304`` (Y.K, T.S.).
+
+* Added a minor ticks back to corner plots in ``xpsi/PostProcessing/_corner.py``. Previously, these ticks were produced by the customized older GetDist version (T.S.).
 
 Attribution
 ^^^^^^^^^^^

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -115,6 +115,13 @@ post-processing:
 
     conda install -c conda-forge getdist h5py nestcheck fgivenx
 
+.. note::
+
+    However, to get the most updated versions of getdist and nestcheck (which may be needed by
+    some of the X-PSI post-processing features), they should be installed from the source
+    (https://github.com/cmbant/getdist and https://github.com/ejhigson/nestcheck)
+    by cloning the repositories and running ``python setup.py install`` in them.
+
 In addition, some optional miscellaneous packages are:
 
 #. `jupyter <https://jupyter-notebook.readthedocs.io/en/stable/>`_ if you want to run X-PSI in a notebook.

--- a/xpsi/PostProcessing/_corner.py
+++ b/xpsi/PostProcessing/_corner.py
@@ -553,6 +553,15 @@ class CornerPlotter(PostProcessor):
         else:
             plotter.legend.set_frame_on(legend_frameon)
 
+        params = self.params
+        for j in range(len(params.names)):
+                for i in range(j,len(params.names)):
+                    ax = plotter.subplots[i,j]
+                    ax.xaxis.set_minor_locator(AutoMinorLocator())
+                for i in range(j):
+                    ax = plotter.subplots[j,i]
+                    ax.yaxis.set_minor_locator(AutoMinorLocator())
+
         # add custom parameter plotting limits and updated autolocation
         with fragile(verbose(param_plot_lims,
                              'Applying bespoke parameter viewing intervals',


### PR DESCRIPTION
Minor ticks added back to corner plots by default and suggestion in the documentation added to install GetDist and NestCheck from source (instead of conda) in case of want to have the most updated versions.