### PR TITLE
Fix to combining multiple runs.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,7 @@ and this project adheres to
 .. ^^^^^^^^^^^
 
 
-[pre-v2.0.3] - 2023-07-04
+[pre-v2.0.3] - 2023-07-09
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Summary
@@ -46,6 +46,8 @@ Fixed
 ^^^^^
 
 * Fixed a bug when defining ``param_plot_lims`` in ``xpsi/PostProcessing/_corner.py`` caused by ``tight_gap_fraction`` being only defined in the customized GetDist version that is not used anymore. That parameter is now defined in X-PSI instead (T.S., Y.K., S.G.).
+
+* Fixed a bug when combining multiple runs in ``xpsi/PostProcessing/_runs.py``, which caused the combination sometimes fail since PolyChord (instead of MultiNest) default was used for the initial live point likelihoods in dead-birth files. This bug appeared after switching to use a non-customized version of NestCheck (after X-PSI version 2.0.0). Now the newest NestCheck version allows to change this value, and this change is now done within X-PSI. If trying to use an older NestCheck version, an error is raised (T.S., Y.K.).
 
 Added
 ^^^^^

--- a/xpsi/PostProcessing/_runs.py
+++ b/xpsi/PostProcessing/_runs.py
@@ -185,12 +185,24 @@ class Runs(Metadata):
             run['output']['base_dir'] = base_dir
             run['output']['file_root'] = file_root
 
-            write_run_output(run,
-                             write_dead = True,
-                             write_stats = True,
-                             posteriors = True,
-                             stats_means_errs = True,
-                             n_simulate = 1000)
+            try:
+                #use MultiNest initial likelihood (logl_init) instead of the default PolyChord
+                write_run_output(run,
+                                 write_dead = True,
+                                 write_stats = True,
+                                 posteriors = True,
+                                 stats_means_errs = True,
+                                 n_simulate = 1000,
+                                 logl_init = -0.179769313486231571E+309)
+            except TypeError as e:
+                if str(e) == "Unexpected **kwargs: {'logl_init': -1.7976931348623157e+308}":
+                    raise TypeError("The used nestcheck version does not support combining "
+                    "MultiNest runs in X-PSI. To use this feature, nestcheck version newer "
+                    "than in this commit: "
+                    "https://github.com/ejhigson/nestcheck/commit/513ef962ef7b0d66377686f9fe0a9e354dad48b3 "
+                    "should be used (see installation instructions for installing it from github).")
+                else:
+                    raise
 
         kwargs = {'kde_settings': self.kde_settings,
                   'ID': 'combined',


### PR DESCRIPTION
Fixed a bug when combining multiple runs in ``xpsi/PostProcessing/_runs.py``, which caused the combination sometimes fail since PolyChord (instead of MultiNest) default was used for the initial live point likelihoods in dead-birth files. This bug appeared after switching to use a non-customized version of NestCheck (after X-PSI version 2.0.0). Now the newest NestCheck version allows to change this value, and this change is now done within X-PSI. If trying to use an older NestCheck version, an error is raised.