### PR TITLE
Use NestCheck both with and without hyphens in file names.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,8 @@ Fixed
 
 * Fixed a bug when combining multiple runs in ``xpsi/PostProcessing/_runs.py``, which caused the combination sometimes fail since PolyChord (instead of MultiNest) default was used for the initial live point likelihoods in dead-birth files. This bug appeared after switching to use a non-customized version of NestCheck (after X-PSI version 2.0.0). Now the newest NestCheck version allows to change this value, and this change is now done within X-PSI. If trying to use an older NestCheck version, an error is raised (T.S., Y.K.).
 
+* Fixed the hyphens in the file names in ``xpsi/PostProcessing/_backends.py`` when reading MultiNest output files with the newest NestCheck version from GitHub, although trying still to read the filenames also with the older syntax to allow older NestCheck versions for other things than combining runs (T.S.).
+
 Added
 ^^^^^
 * Added a keyword argument in ``xpsi/PostProcessing/_corner.py`` to allow user to define the decimal precisions for all the credible intervals printed in the figures (T.S.).

--- a/xpsi/PostProcessing/_backends.py
+++ b/xpsi/PostProcessing/_backends.py
@@ -103,12 +103,26 @@ class NestedBackend(Run):
             except KeyError:
                 print('Root %r sampling implementation not specified... '
                       'assuming MultiNest for nestcheck...')
-                self._nc_bcknd = process_multinest_run(root,
+                try:
+                    self._nc_bcknd = process_multinest_run(root,
                                                        base_dir=base_dir)
+                except:
+                    try:
+                        self._nc_bcknd = process_multinest_run(root+"-",
+                                                       base_dir=base_dir)
+                    except:
+                        raise
             else:
                 if kwargs['implementation'] == 'multinest':
-                    self._nc_bcknd = process_multinest_run(root,
+                    try:
+                        self._nc_bcknd = process_multinest_run(root,
                                                            base_dir=base_dir)
+                    except:
+                        try:
+                            self._nc_bcknd = process_multinest_run(root+"-",
+                                                           base_dir=base_dir)
+                        except:
+                            raise
                 elif kwargs['implementation'] == 'polychord':
                     self._nc_bcknd = process_polychord_run(root,
                                                            base_dir=base_dir)


### PR DESCRIPTION
Fixed the hyphens in the file names in ``xpsi/PostProcessing/_backends.py`` when reading MultiNest output files with the newest NestCheck version from GitHub, although trying still to read the filenames also with the older syntax to allow older NestCheck versions for other things than combining runs. 

Also, the Post-processing notebook of the documentation pages has been now re-run with the latest X-PSI changes.