### PR TITLE
Installation and script fixes

### DIFF
--- a/docs/source/Example_job.rst
+++ b/docs/source/Example_job.rst
@@ -31,10 +31,10 @@ The following job script ``job.sh`` is an example job script for analysis on the
     module purge
 
     module load 2022
+    module load intel/2022a
     module load Anaconda3/2022.05
     source /sw/arch/RHEL8/EB_production/2022/software/Anaconda3/2022.05/etc/profile.d/conda.sh
     conda activate xpsi_py3
-    module load intel/2022a
     
     cp -r $HOME/xpsi/examples/examples_modeling_tutorial/* $TMPDIR/
     mkdir $TMPDIR/run
@@ -81,8 +81,8 @@ For Helios, we can use the following type of job script:
 
     module purge
     module load anaconda3/2021-05
-    conda activate xpsi_py3
     module load openmpi/3.1.6
+    conda activate xpsi_py3
 
     export OMP_NUM_THREADS=1
     export OPENBLAS_NUM_THREADS=1

--- a/docs/source/HPC_systems.rst
+++ b/docs/source/HPC_systems.rst
@@ -230,9 +230,10 @@ Let's start by loading the necessary modules and creating a conda environment. A
 
 .. code-block:: bash
 
+   module load anaconda3/2021-05
+   module load openmpi/3.1.6
    git clone https://github.com/xpsi-group/xpsi.git
    cd xpsi
-   module load anaconda3/2021-05
    conda create -n xpsi_py3 python=3.10.6
    conda activate xpsi_py3
    conda install -c conda-forge mpi4py
@@ -240,10 +241,6 @@ Let's start by loading the necessary modules and creating a conda environment. A
    conda install scipy
    conda install matplotlib
    conda install wrapt   
-   
-.. code-block:: bash
-
-   module load openmpi/3.1.6
      
 Let's then test if mpi4py works:
 

--- a/docs/source/HPC_systems.rst
+++ b/docs/source/HPC_systems.rst
@@ -236,7 +236,7 @@ Let's start by loading the necessary modules and creating a conda environment. A
    conda create -n xpsi_py3 python=3.10.6
    conda activate xpsi_py3
    conda install -c conda-forge mpi4py
-   conda install cython ~= 0.29
+   conda install cython~=0.29
    conda install scipy
    conda install matplotlib
    conda install wrapt   
@@ -336,7 +336,7 @@ Then, create the conda environnnement and Install python packages with conda (or
     conda create -n xpsi --clone base
     conda activate xpsi
     conda install numpy scipy matplotlib wrapt
-    conda install cython ~= 0.29
+    conda install cython~=0.29
     conda install h5py
     conda install -c conda-forge fgivenx
     pip install schwimmbad --user


### PR DESCRIPTION
Removed spaces before and after "~=" when conda installing `cython~=0.29` (otherwise it does not work).

I also changed the module loading order in the HPC example jobs to match that used when installing X-PSI and for Helios loading now the openmpi module **before** installing mpi4py (and before activating x-psi environment) as suggested previously by Martin.