### PR TITLE
Numerical fix in KL-divergence calculation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,20 @@ and this project adheres to
 .. ^^^^^^^^^^^
 
 
+[pre-v2.1.1] - 2023-09-26
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Prior probability values prevented from being exactly zero (or negative) for KL-divergence calculation and avoiding thus infinite values for the reported KL-divergence estimates (T.S.).
+
+Attribution
+^^^^^^^^^^^
+
+Tuomo Salmi
+
+
 [v2.1.0] - 2023-09-08
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/xpsi/PostProcessing/_corner.py
+++ b/xpsi/PostProcessing/_corner.py
@@ -812,9 +812,11 @@ class CornerPlotter(PostProcessor):
                     except:
                         p = weighted_1d_gaussian_kde(x[where], x, w_rel)
                     # Due to spline interpolation, very small densities can be
-                    # negative, so manually give a small postive value which
+                    # negative, so manually give a small positive value which
                     # does not affect KL integral approximation
                     p[p<=0.0] = p[p>0.0].min()
+                    # Prevent also negative or zero values for the prior
+                    prior[prior<=0.0] = prior[prior>0.0].min()
 
                     KL = _np.sum(w_rel[where] \
                                    * (_np.log(p) - _np.log(prior))) \


### PR DESCRIPTION
Preventing the prior probability values from being exactly zero (or negative) for KL-divergence calculation to prevent infinite values for the log-probabilities.