### PR TITLE
Fix to failing continuous integration GitHub Actions

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -25,15 +25,18 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Conda environment with Micromamba
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v1
       with:
-        cache-env: true
+        cache-environment: true
         cache-env-key: env-envkey-${{ github.sha }}-${{ github.run_attempt }}
         environment-file: basic_environment.yml
         environment-name: xpsipy3
+        create-args: >-
+          python=${{ matrix.python-version }}
     - name: mamba install flake8
       run: |
-        micromamba install "python<3.12"
+        python --version
+        # micromamba install "python<3.12"
         micromamba install flake8
     - name: mamba install pytest
       run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,12 +31,13 @@ jobs:
         cache-env-key: env-envkey-${{ github.sha }}-${{ github.run_attempt }}
         environment-file: basic_environment.yml
         environment-name: xpsipy3
-    - name: Make sure metadata not too new for flake8
-      run: |
-        pip install "importlib-metadata<4.3"
     - name: pip install flake8
       run: |
-        pip install flake8==4.0.1 importlib-metadata<4.3
+        pip install "flake8==4.0.1"
+    - name: pip install importlib-metadata
+      run: |
+        pip install "importlib-metadata<4.3"
+        pip show importlib-metadata
     - name: mamba install pytest
       run: |
         micromamba install pytest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -36,7 +36,7 @@ jobs:
         pip install "importlib-metadata<4.3"
     - name: mamba installs
       run: |
-        micromamba install flake8 pytest
+        micromamba install flake8==4.0.1 pytest
     - name: Set up GCC
       run: |
          sudo apt-get install -y gcc

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,7 +33,7 @@ jobs:
         environment-name: xpsipy3
     - name: mamba install flake8 and importlib-metadata
       run: |
-        micromamba install flake8==4.0.1 "importlib-metadata<4.3"
+        micromamba install flake8==4.0.1 importlib-metadata==4.13.0
     - name: mamba install pytest
       run: |
         micromamba install pytest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,7 +33,7 @@ jobs:
         environment-name: xpsipy3
     - name: mamba install flake8
       run: |
-        python --version
+        micromamba install "python<3.12"
         micromamba install flake8
     - name: mamba install pytest
       run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -34,9 +34,12 @@ jobs:
     - name: Make sure metadata not too new for flake8
       run: |
         pip install "importlib-metadata<4.3"
-    - name: mamba installs
+    - name: mamba install flake8
       run: |
-        micromamba install flake8==4.0.1 pytest
+        micromamba install flake8==4.0.1
+    - name: mamba install pytest
+      run: |
+        micromamba install pytest
     - name: Set up GCC
       run: |
          sudo apt-get install -y gcc

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -36,7 +36,7 @@ jobs:
         pip install "importlib-metadata<4.3"
     - name: mamba install flake8
       run: |
-        micromamba install flake8==4.0.1
+        micromamba install flake8==4.0.1 importlib-metadata<4.3
     - name: mamba install pytest
       run: |
         micromamba install pytest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -28,7 +28,7 @@ jobs:
       uses: mamba-org/setup-micromamba@v1
       with:
         cache-environment: true
-        cache-env-key: env-envkey-${{ github.sha }}-${{ github.run_attempt }}
+        cache-environment-key: env-envkey-${{ github.sha }}-${{ github.run_attempt }}
         environment-file: basic_environment.yml
         environment-name: xpsipy3
         create-args: >-

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,7 +33,7 @@ jobs:
         environment-name: xpsipy3
     - name: mamba install flake8
       run: |
-        micromamba install flake8 #==6.0.0
+        micromamba install flake8
     - name: mamba install pytest
       run: |
         micromamba install pytest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,6 +33,7 @@ jobs:
         environment-name: xpsipy3
     - name: mamba install flake8
       run: |
+        python --version
         micromamba install flake8
     - name: mamba install pytest
       run: |
@@ -48,9 +49,9 @@ jobs:
       run: |
         # micromamba list | grep importlib-metadata
         # stop the build if there are Python syntax errors or undefined names
-        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: install X-PSI package
       run: |
         python setup.py install

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,7 +33,7 @@ jobs:
         environment-name: xpsipy3
     - name: mamba install flake8
       run: |
-        micromamba install flake8==4.0.1
+        micromamba install flake8==5.0.4
     - name: mamba install importlib-metadata
       run: |
         micromamba install "importlib-metadata<4.3"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,14 +33,9 @@ jobs:
         environment-name: xpsipy3
         create-args: >-
           python=${{ matrix.python-version }}
-    - name: mamba install flake8
+    - name: mamba installs
       run: |
-        python --version
-        # micromamba install "python<3.12"
-        micromamba install flake8
-    - name: mamba install pytest
-      run: |
-        micromamba install pytest
+        micromamba install flake8 pytest
     - name: Set up GCC
       run: |
          sudo apt-get install -y gcc

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,12 +31,9 @@ jobs:
         cache-env-key: env-envkey-${{ github.sha }}-${{ github.run_attempt }}
         environment-file: basic_environment.yml
         environment-name: xpsipy3
-    - name: mamba install flake8
+    - name: mamba install flake8 and importlib-metadata
       run: |
-        micromamba install flake8==4.0.1
-    - name: mamba install importlib-metadata
-      run: |
-        micromamba install "importlib-metadata<4.3"
+        micromamba install flake8==4.0.1 "importlib-metadata<4.3"
     - name: mamba install pytest
       run: |
         micromamba install pytest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,12 +31,12 @@ jobs:
         cache-env-key: env-envkey-${{ github.sha }}-${{ github.run_attempt }}
         environment-file: basic_environment.yml
         environment-name: xpsipy3
-    - name: pip install flake8
+    - name: mamba install flake8
       run: |
-        pip install "flake8==4.0.1"
-    - name: pip install importlib-metadata
+        mamba install "flake8==4.0.1"
+    - name: mamba install importlib-metadata
       run: |
-        pip install "importlib-metadata<4.3"
+        mamba install "importlib-metadata<4.3"
     - name: mamba install pytest
       run: |
         micromamba install pytest
@@ -49,7 +49,7 @@ jobs:
         sudo apt-get install -y libgsl-dev
     - name: Lint with flake8
       run: |
-        pip show importlib-metadata
+        mamba show importlib-metadata
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,7 +33,7 @@ jobs:
         environment-name: xpsipy3
     - name: mamba install flake8
       run: |
-        micromamba install flake8==6.0.0
+        micromamba install flake8 #==6.0.0
     - name: mamba install pytest
       run: |
         micromamba install pytest
@@ -48,9 +48,9 @@ jobs:
       run: |
         # micromamba list | grep importlib-metadata
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: install X-PSI package
       run: |
         python setup.py install

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -36,7 +36,7 @@ jobs:
         micromamba install flake8==4.0.1
     - name: mamba install importlib-metadata
       run: |
-        micromamba install importlib-metadata<4.3
+        micromamba install "importlib-metadata<4.3"
     - name: mamba install pytest
       run: |
         micromamba install pytest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,6 +31,9 @@ jobs:
         cache-env-key: env-envkey-${{ github.sha }}-${{ github.run_attempt }}
         environment-file: basic_environment.yml
         environment-name: xpsipy3
+    - name: Make sure metadata not too new for flake8
+      run: |
+        pip install "importlib-metadata<4.3"
     - name: mamba installs
       run: |
         micromamba install flake8 pytest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -31,9 +31,9 @@ jobs:
         cache-env-key: env-envkey-${{ github.sha }}-${{ github.run_attempt }}
         environment-file: basic_environment.yml
         environment-name: xpsipy3
-    - name: mamba install flake8 and importlib-metadata
+    - name: mamba install flake8
       run: |
-        micromamba install flake8==4.0.1 "importlib-metadata<5.0"
+        micromamba install flake8==6.0.0
     - name: mamba install pytest
       run: |
         micromamba install pytest
@@ -46,7 +46,7 @@ jobs:
         sudo apt-get install -y libgsl-dev
     - name: Lint with flake8
       run: |
-        micromamba list | grep importlib-metadata
+        # micromamba list | grep importlib-metadata
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,10 +33,10 @@ jobs:
         environment-name: xpsipy3
     - name: mamba install flake8
       run: |
-        mamba install flake8==4.0.1
+        micromamba install flake8==4.0.1
     - name: mamba install importlib-metadata
       run: |
-        mamba install importlib-metadata<4.3
+        micromamba install importlib-metadata<4.3
     - name: mamba install pytest
       run: |
         micromamba install pytest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,10 +33,10 @@ jobs:
         environment-name: xpsipy3
     - name: mamba install flake8
       run: |
-        mamba install "flake8==4.0.1"
+        mamba install flake8==4.0.1
     - name: mamba install importlib-metadata
       run: |
-        mamba install "importlib-metadata<4.3"
+        mamba install importlib-metadata<4.3
     - name: mamba install pytest
       run: |
         micromamba install pytest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,7 +33,7 @@ jobs:
         environment-name: xpsipy3
     - name: mamba install flake8 and importlib-metadata
       run: |
-        micromamba install flake8==4.0.1 importlib-metadata==4.13.0
+        micromamba install flake8==4.0.1 "importlib-metadata<5.0"
     - name: mamba install pytest
       run: |
         micromamba install pytest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -37,7 +37,6 @@ jobs:
     - name: pip install importlib-metadata
       run: |
         pip install "importlib-metadata<4.3"
-        pip show importlib-metadata
     - name: mamba install pytest
       run: |
         micromamba install pytest
@@ -50,6 +49,7 @@ jobs:
         sudo apt-get install -y libgsl-dev
     - name: Lint with flake8
       run: |
+        pip show importlib-metadata
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,7 +33,7 @@ jobs:
         environment-name: xpsipy3
     - name: mamba install flake8
       run: |
-        micromamba install flake8==5.0.4
+        micromamba install flake8==4.0.1
     - name: mamba install importlib-metadata
       run: |
         micromamba install "importlib-metadata<4.3"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -34,9 +34,9 @@ jobs:
     - name: Make sure metadata not too new for flake8
       run: |
         pip install "importlib-metadata<4.3"
-    - name: mamba install flake8
+    - name: pip install flake8
       run: |
-        micromamba install flake8==4.0.1 importlib-metadata<4.3
+        pip install flake8==4.0.1 importlib-metadata<4.3
     - name: mamba install pytest
       run: |
         micromamba install pytest

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -45,7 +45,6 @@ jobs:
         sudo apt-get install -y libgsl-dev
     - name: Lint with flake8
       run: |
-        # micromamba list | grep importlib-metadata
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -49,7 +49,7 @@ jobs:
         sudo apt-get install -y libgsl-dev
     - name: Lint with flake8
       run: |
-        mamba show importlib-metadata
+        micromamba list | grep importlib-metadata
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide


### PR DESCRIPTION
Fixed here the `flake8` issue by correcting python version setting when creating conda environment with micromamba. Apparently, we have so far in practice always used the newest python version for all the CI-tests, even though trying to do it separately for 3.8, 3.9, 3.10, and 3.11. And now when the newest version is 3.12, all the tests failed because the `flake8 `package seems broken for that version (at least I could not install it without getting an inconsistent version for the needed `importlib-metadata` package as mentioned in the issue #340). 

I fixed the conda environment creation to actually use the intended python versions and also switched from the deprecated `provision-with-micromamba` method to the `setup-micromamba` method as explained [here](https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba%60).