### PR TITLE
Small typos, bugs, and HPC installation fixes

### DIFF
--- a/docs/source/FAQ.rst
+++ b/docs/source/FAQ.rst
@@ -72,7 +72,7 @@ Can happen in PostProcessing for runs with ``use_nestcheck=[False]`` (e.g. impor
       :alt: image
       :width: 10cm
 
-The problem is the ``xpsi/xpsi/surface_radiation_field/local_variable.pyx`` file which should be overwritten by ``xpsi/xpsi/surface_radiation_field/archive/local_variables/PST_U.pyx`` or ``xpsi/xpsi/surface_radiation_field/archive/local_variables/two_spots.pyx`` (depending on the model) and then re-install X-PSI.
+The problem is the ``xpsi/xpsi/surface_radiation_field/local_variables.pyx`` file which should be overwritten by ``xpsi/xpsi/surface_radiation_field/archive/local_variables/PST_U.pyx`` or ``xpsi/xpsi/surface_radiation_field/archive/local_variables/two_spots.pyx`` (depending on the model) and then re-install X-PSI.
 
 .. rubric:: *ImportError: No module named tools*
 

--- a/docs/source/HPC_systems.rst
+++ b/docs/source/HPC_systems.rst
@@ -84,9 +84,9 @@ To prepare MPI from ``$HOME``:
 
 .. code-block:: bash
 
-    cd; wget https://bitbucket.org/mpi4py/mpi4py/downloads/mpi4py-3.1.4.tar.gz
-    tar zxvf mpi4py-3.1.4.tar.gz
-    cd mpi4py-3.1.4
+    cd; wget https://github.com/mpi4py/mpi4py/releases/download/3.1.5/mpi4py-3.1.5.tar.gz
+    tar zxvf mpi4py-3.1.5.tar.gz
+    cd mpi4py-3.1.5
     python setup.py build   --mpicc=/sw/arch/RHEL8/EB_production/2022/software/impi/2021.6.0-intel-compilers-2022.1.0/mpi/2021.6.0/bin/mpicc
     python setup.py install
 
@@ -246,9 +246,9 @@ Let's then test if mpi4py works:
 
 .. code-block:: bash
 
-   cd; wget https://bitbucket.org/mpi4py/mpi4py/downloads/mpi4py-3.1.4.tar.gz
-   tar zxvf mpi4py-3.1.4.tar.gz
-   cd mpi4py-3.1.4
+   cd; wget https://github.com/mpi4py/mpi4py/releases/download/3.1.5/mpi4py-3.1.5.tar.gz
+   tar zxvf mpi4py-3.1.5.tar.gz
+   cd mpi4py-3.1.5
    mpiexec -n 4 python demo/helloworld.py
    
 Let's then install MultiNest and PyMultiNest:
@@ -259,7 +259,7 @@ Let's then install MultiNest and PyMultiNest:
    cd multinest/MultiNest_v3.12_CMake/multinest
    mkdir build
    cd build
-   CC=gcc FC=mpif90 CXX=g++ cmake -DCMAKE_{C,CXX}_FLAGS="-O3 -march=native -funroll-loops" -DCMAKE_Fortran_FLAGS="-O3 -march=native -funroll-loops" ..
+   CC=gcc FC=/zfs/helios/filer0/sw-astro/api/openmpi/3.1.6/bin/mpif90 CXX=g++ cmake -DCMAKE_{C,CXX}_FLAGS="-O3 -march=native -funroll-loops" -DCMAKE_Fortran_FLAGS="-O3 -march=native -funroll-loops" ..
    make
    
 .. code-block:: bash
@@ -280,7 +280,7 @@ Let's then install GSL:
 .. code-block:: bash
 
    cd; wget -v http://mirror.koddos.net/gnu/gsl/gsl-latest.tar.gz
-   tar -xzvf gsl-{latest}
+   tar -xzvf gsl-latest.tar.gz
    cd gsl-{latest} 
    ./configure CC=gcc --prefix=$HOME/gsl
    make
@@ -352,9 +352,9 @@ Install mpi4py in your ``$HOME`` (e.g. in ``~/Softwares``):
 
     mkdir Softwares
     cd Softwares
-    wget https://bitbucket.org/mpi4py/mpi4py/downloads/mpi4py-3.1.4.tar.gz
-    tar zxvf mpi4py-3.1.4.tar.gz
-    cd mpi4py-3.1.4
+    wget https://github.com/mpi4py/mpi4py/releases/download/3.1.5/mpi4py-3.1.5.tar.gz
+    tar zxvf mpi4py-3.1.5.tar.gz
+    cd mpi4py-3.1.5
     python setup.py build
     python setup.py install
     # Test on login node:

--- a/docs/source/Modeling_without_statistics.ipynb
+++ b/docs/source/Modeling_without_statistics.ipynb
@@ -1436,7 +1436,7 @@
     "        \n",
     "    :param tuple shift: Hot region phase parameters.\n",
     "    \n",
-    "    :param ndarray[m] x: Energy values the signal is resolved at.\n",
+    "    :param ndarray[m] y: Energy values the signal is resolved at.\n",
     "    \n",
     "    \"\"\"\n",
     "    \n",
@@ -2079,7 +2079,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/xpsi/Photosphere.py
+++ b/xpsi/Photosphere.py
@@ -1673,7 +1673,7 @@ class Photosphere(ParameterSubspace):
                                 levels[-1] = _np.array([0.0, 0.001*MIN] + list(levels[-1]))
             else:
                 with verbose(True,
-                             'Normalising sky map panels globally'
+                             'Normalising sky map panels globally',
                              'Normalised sky map panels globally'):
                     MIN = _np.min(images[:,:,:][images[:,:,:] > 0.0])
                     MAX = _np.max(images[:,:,:])


### PR DESCRIPTION
HPC installation instructions have been updated to use the latest mpi4py version (3.1.5) when downloading it from the source. The previous ones do not work with the newest Python version (3.12). Some other small fixes to the instructions were done too. Fixed also some typos in the documentation and a bug in the code creating sky maps.

