### PR TITLE
PDT-U projection tool bug fixed and units set to roman font.

### DIFF
--- a/xpsi/utilities/ProjectionTool.py
+++ b/xpsi/utilities/ProjectionTool.py
@@ -307,6 +307,7 @@ def plot_projection_general(dictVp, model, POV = "", ThetaDisplay = "",antiphase
             elif ('-U' in model):
                 ind = model.find('-')
                 hot_name = model[:ind]
+                hot_name_s = model[:ind]
                 hotspot_check(hot_name,DICT_VECTOR,'p')
                 hotspot_check(hot_name,DICT_VECTOR,'s')
             
@@ -920,10 +921,10 @@ def plot_projection_general(dictVp, model, POV = "", ThetaDisplay = "",antiphase
             else:
                 transform_plot_lines(thetaA_anti[i],phiA_anti[i],Vi,CAall[i],NO_POLE_FLAG,'-.',2)
                 
-    L1 = r'$\phi=0\,[cycle],\, \theta = \pi/2\,[rad]$'
+    L1 = r'$\phi=0\,[\mathrm{cycle}],\, \theta = \pi/2\,[\mathrm{rad}]$'
     transform_plot(np.pi*0.5,0.0,[0,0,1],5,False,'o', mycolors1[2], True,L1, '')
 
-    L1 = r'$\phi=0.125\,[cycle],\, \theta = \pi/2\,[rad]$'
+    L1 = r'$\phi=0.125\,[\mathrm{cycle}],\, \theta = \pi/2\,[\mathrm{rad}]$'
     transform_plot(np.pi*0.5,0.125,[0,0,1],5,False,'D', mycolors1[2], True,L1, '')
 
 


### PR DESCRIPTION
Bug in the projection tool for PDT-U model fixed (the components of the secondary region were not shown). In addition, the font type of the units was changed from italic to roman. Here a figure before the update
![Projection_from_PrimarySuper_old](https://github.com/xpsi-group/xpsi/assets/16220573/2db77b9b-a2b4-4b2f-ac30-1f0fa67f34c4)
and here the same figure after the update:
![Projection_from_PrimarySuper_new](https://github.com/xpsi-group/xpsi/assets/16220573/e9cc5afc-b775-4499-9cab-0a7af87e6fcf)

I also checked that the code still works correctly for ST-U. 