### PR TITLE
Snellius instructions updated

### DIFF
--- a/docs/source/Example_job.rst
+++ b/docs/source/Example_job.rst
@@ -31,10 +31,13 @@ The following job script ``job.sh`` is an example job script for analysis on the
     module purge
 
     module load 2022
-    module load intel/2022a
-    module load Anaconda3/2022.05
-    source /sw/arch/RHEL8/EB_production/2022/software/Anaconda3/2022.05/etc/profile.d/conda.sh
-    conda activate xpsi_py3
+    module load foss/2022a
+    module load SciPy-bundle/2022.05-foss-2022a
+    module load wrapt/1.15.0-foss-2022a
+    module load matplotlib/3.5.2-foss-2022a
+    module load CMake/3.23.1-GCCcore-11.3.0
+
+    source $HOME/venvs/xpsi_py3/bin/activate
     
     cp -r $HOME/xpsi/examples/examples_modeling_tutorial/* $TMPDIR/
     mkdir $TMPDIR/run
@@ -43,14 +46,10 @@ The following job script ``job.sh`` is an example job script for analysis on the
     export OMP_NUM_THREADS=1
     export OPENBLAS_NUM_THREADS=1
     export GOTO_NUM_THREADS=1
-    export MKL_NUM_THREADS=1
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/multinest/MultiNest_v3.12_CMake/multinest/lib/
-    
-    export LD_PRELOAD=/sw/arch/Centos8/EB_production/2021/software/imkl/2021.2.0-iimpi-2021a/mkl/2021.2.0/lib/intel64/libmkl_def.so.1:/sw/arch/Centos8/EB_production/2021/software/imkl/2021.2.0-iimpi-2021a/mkl/2021.2.0/lib/intel64/libmkl_avx2.so.1:/sw/arch/Centos8/EB_production/2021/software/imkl/2021.2.0-iimpi-2021a/mkl/2021.2.0/lib/intel64/libmkl_core.so:/sw/arch/Centos8/EB_production/2021/software/imkl/2021.2.0-iimpi-2021a/mkl/2021.2.0/lib/intel64/libmkl_intel_lp64.so:/sw/arch/Centos8/EB_production/2021/software/imkl/2021.2.0-iimpi-2021a/mkl/2021.2.0/lib/intel64/libmkl_intel_thread.so:/sw/arch/Centos8/EB_production/2021/software/imkl/2021.2.0-iimpi-2021a/compiler/2021.2.0/linux/compiler/lib/intel64_lin/libiomp5.so
 
     srun python TestRun_BB.py > out1 2> err1
-    cp out1 err1 $HOME/xpsi/examples/examples_modeling_tutorial/.
-    cp -r run $HOME/xpsi/examples/examples_modeling_tutorial/
+    cp -r out1 err1 run $HOME/xpsi/examples/examples_modeling_tutorial/.
     #end of job file
 
 This can be submitted with ``sbatch job.sh``. In a corresponding resume script one would typically increase the number of processes. This is because parallelisation efficiency scales with the local rejection fraction during a nested sampling iteration. Make sure that also the previous sample output files are copied to the $TMPDIR directory, and that the resume option for MultiNest is turned on in the main Python file (in ``TestRun_BB.py`` for this example).

--- a/docs/source/HPC_systems.rst
+++ b/docs/source/HPC_systems.rst
@@ -95,6 +95,10 @@ Now you need the Python interface to MultiNest, starting from ``$HOME``:
     cd ~/pymultinest
     python setup.py install
 
+.. note::
+
+    If not using a Python virtual environment, you should add ``--user`` flag when installing PyMultiNest.
+
 To test the installation of MultiNest and PyMultiNest on the login node:
 
 .. code-block:: bash
@@ -122,6 +126,10 @@ only need:
 
     cd ~/xpsi
     LDSHARED="gcc -shared" CC=gcc python setup.py install
+
+.. note::
+
+    If not using a Python virtual environment, you should add ``--user`` flag when installing X-PSI.
 
 If you ever need to reinstall, first clean to recompile C files:
 

--- a/docs/source/HPC_systems.rst
+++ b/docs/source/HPC_systems.rst
@@ -54,7 +54,7 @@ Prepare a new Python virtual environment for X-PSI (named for example "xpsi_py3"
     mkdir venvs
     python -m venv ./venvs/xpsi_py3
 
-To access all the loaded site packages when activating the virtual environment, one needs to modify the file ``./venvs/xpsi_py3/Pyvenv.cfg`` (using e.g. ``vim`` or ``emacs`` text editor) to change "false" into "true":
+To access all the loaded site packages when activating the virtual environment, one needs to modify the file ``./venvs/xpsi_py3/pyvenv.cfg`` (using e.g. ``vim`` or ``emacs`` text editor) to change "false" into "true":
 
 .. code-block:: bash
 
@@ -124,6 +124,7 @@ only need:
 
 .. code-block:: bash
 
+    git clone https://github.com/xpsi-group/xpsi.git
     cd ~/xpsi
     LDSHARED="gcc -shared" CC=gcc python setup.py install
 

--- a/docs/source/acknowledgements.rst
+++ b/docs/source/acknowledgements.rst
@@ -77,7 +77,7 @@ direction of this project or led to some specific improvements.
   and about model space definitions)
 * Will M. Farr (for ideas to accelerate likelihood function evaluation; WIP)
 * Sam Geen (for expanding support to include Windows OS)
-* Martin Heemskerk, Jeroen Roodhart and the SurfSARA servicedesk (for help with HPC issues).
+* Martin Heemskerk, Jeroen Roodhart, Satish Kamath and the SurfSARA servicedesk (for help with HPC issues).
 
 Literature
 ~~~~~~~~~~


### PR DESCRIPTION
Snellius installation instructions (and the example job script) update based on the recommendations and tests from Satish Kamath and @Basdorsman (to improve the performance).

Changes summarized:

- Using foss instead of intel
- Using python virtual environment (if wanted) instead of conda
- A few flags changed when installing MultiNest