### PR TITLE
Example script updates

### DIFF
--- a/examples/examples_fast/Modules/CustomPrior.py
+++ b/examples/examples_fast/Modules/CustomPrior.py
@@ -59,7 +59,7 @@ class CustomPrior(xpsi.Prior):
 
         # Compactness limit
         R_p = 1.0 + ref.epsilon * (-0.788 + 1.030 * ref.zeta)
-        if R_p < 1.76 / ref.R_r_s:
+        if R_p < 1.505 / ref.R_r_s:
             return -np.inf
 
         mu = math.sqrt(-1.0 / (3.0 * ref.epsilon * (-0.788 + 1.030 * ref.zeta)))

--- a/examples/examples_fast/Synthetic_data.ipynb
+++ b/examples/examples_fast/Synthetic_data.ipynb
@@ -399,14 +399,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Hot-spot"
+    "# Hot spot"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### We will use a single hot-spot. For complex models, see:\n",
+    "### We will use a single hot spot. For complex models, see:\n",
     "https://xpsi-group.github.io/xpsi\n",
     "\n"
    ]
@@ -455,7 +455,8 @@
     "                            max_sqrt_num_cells=64,\n",
     "                            num_leaves=100,\n",
     "                            num_rays=200,\n",
-    "                            is_antiphased=True, \n",
+    "                            is_antiphased=True,\n",
+    "                            image_order_limit=3, # up to tertiary\n",
     "                            prefix='hot') # unique prefix needed because >1 instance\n"
    ]
   },
@@ -470,7 +471,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### We will use  here the defaulf black-body emission model. No emission from the rest of the star, all the emission is from the hot-spot"
+    "### We will use  here the default black-body emission model. No emission from the rest of the star, all the emission is from the hot spot"
    ]
   },
   {
@@ -593,7 +594,7 @@
     "\n",
     "        # Compactness limit\n",
     "        R_p = 1.0 + ref.epsilon * (-0.788 + 1.030 * ref.zeta)\n",
-    "        if R_p < 1.76 / ref.R_r_s:\n",
+    "        if R_p < 1.505 / ref.R_r_s:\n",
     "            return -np.inf\n",
     "\n",
     "        mu = math.sqrt(-1.0 / (3.0 * ref.epsilon * (-0.788 + 1.030 * ref.zeta)))\n",
@@ -828,7 +829,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Synthesing function"
+    "# Synthesising function"
    ]
   },
   {
@@ -885,6 +886,11 @@
     "                    filename = os.path.join(directory, name+'_realisation_hreadable.dat'),\n",
     "                    fmt = '%u')\n",
     "\n",
+    "        #if you would like to save the data without noise (for testing purposes), you can do this:\n",
+    "        #np.savetxt(os.path.join(directory, name+'_realisation_no_noise.dat'),\n",
+    "        #           np.round(self._expected_counts),\n",
+    "        #           fmt = '%u')        \n",
+    "        \n",
     "def _write(self, counts, filename, fmt):\n",
     "        \"\"\" Write to file in human readable format. \"\"\"\n",
     "\n",
@@ -1107,7 +1113,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/examples/examples_modeling_tutorial/TestRun_BB.py
+++ b/examples/examples_modeling_tutorial/TestRun_BB.py
@@ -124,18 +124,19 @@ bounds = dict(super_colatitude = (None, None),
               super_temperature = (5.1, 6.8))
 
 primary = xpsi.HotRegion(bounds=bounds,
-	                    values={},
-	                    symmetry=True,
-	                    omit=False,
-	                    cede=False,
-	                    concentric=False,
-	                    sqrt_num_cells=32,
-	                    min_sqrt_num_cells=10,
-	                    max_sqrt_num_cells=64,
-	                    num_leaves=100,
-	                    num_rays=200,
-	                    atm_ext="BB",
-	                    prefix='p')
+                        values={},
+                        symmetry=True,
+                        omit=False,
+                        cede=False,
+                        concentric=False,
+                        sqrt_num_cells=32,
+                        min_sqrt_num_cells=10,
+                        max_sqrt_num_cells=64,
+                        num_leaves=100,
+                        num_rays=200,
+                        atm_ext="BB",
+                        image_order_limit=3,
+                        prefix='p')
 
 class derive(xpsi.Derive):
     def __init__(self):
@@ -159,20 +160,21 @@ class derive(xpsi.Derive):
 bounds['super_temperature'] = None # declare fixed/derived variable
 
 secondary = xpsi.HotRegion(bounds=bounds, # can otherwise use same bounds
-	                      values={'super_temperature': derive()},
-	                      symmetry=True,
-	                      omit=False,
-	                      cede=False,
-	                      concentric=False,
-	                      sqrt_num_cells=32,
-	                      min_sqrt_num_cells=10,
-	                      max_sqrt_num_cells=100,
-	                      num_leaves=100,
-	                      num_rays=200,
-	                      do_fast=False,
-	                      atm_ext="BB",
-	                      is_antiphased=True,
-	                      prefix='s')
+                            values={'super_temperature': derive()},
+                            symmetry=True,
+                            omit=False,
+                            cede=False,
+                            concentric=False,
+                            sqrt_num_cells=32,
+                            min_sqrt_num_cells=10,
+                            max_sqrt_num_cells=100,
+                            num_leaves=100,
+                            num_rays=200,
+                            do_fast=False,
+                            atm_ext="BB",
+                            image_order_limit=3,
+                            is_antiphased=True,
+                            prefix='s')
 
 
 from xpsi import HotRegions
@@ -351,11 +353,9 @@ class CustomPrior(xpsi.Prior):
 
         ref = self.parameters.star.spacetime # shortcut
 
-        # limit polar radius to try to exclude deflections >= \pi radians
-        # due to oblateness this does not quite eliminate all configurations
-        # with deflections >= \pi radians
+        # limit polar radius to be outside the Schwarzschild photon sphere
         R_p = 1.0 + ref.epsilon * (-0.788 + 1.030 * ref.zeta)
-        if R_p < 1.76 / ref.R_r_s:
+        if R_p < 1.505 / ref.R_r_s:
             return -np.inf
 
         # polar radius at photon sphere for ~static star (static ambient spacetime)

--- a/examples/examples_modeling_tutorial/TestRun_Num.py
+++ b/examples/examples_modeling_tutorial/TestRun_Num.py
@@ -124,18 +124,19 @@ bounds = dict(super_colatitude = (None, None),
               super_temperature = (5.1, 6.8))
 
 primary = xpsi.HotRegion(bounds=bounds,
-	                    values={},
-	                    symmetry=True,
-	                    omit=False,
-	                    cede=False,
-	                    concentric=False,
-	                    sqrt_num_cells=32,
-	                    min_sqrt_num_cells=10,
-	                    max_sqrt_num_cells=64,
-	                    num_leaves=100,
-	                    num_rays=200,
-	                    atm_ext="Num4D",
-	                    prefix='p')
+                        values={},
+                        symmetry=True,
+                        omit=False,
+                        cede=False,
+                        concentric=False,
+                        sqrt_num_cells=32,
+                        min_sqrt_num_cells=10,
+                        max_sqrt_num_cells=64,
+                        num_leaves=100,
+                        num_rays=200,
+                        atm_ext="Num4D",
+                        image_order_limit=3,
+                        prefix='p')
 
 class derive(xpsi.Derive):
     def __init__(self):
@@ -159,20 +160,21 @@ class derive(xpsi.Derive):
 bounds['super_temperature'] = None # declare fixed/derived variable
 
 secondary = xpsi.HotRegion(bounds=bounds, # can otherwise use same bounds
-	                      values={'super_temperature': derive()},
-	                      symmetry=True,
-	                      omit=False,
-	                      cede=False,
-	                      concentric=False,
-	                      sqrt_num_cells=32,
-	                      min_sqrt_num_cells=10,
-	                      max_sqrt_num_cells=100,
-	                      num_leaves=100,
-	                      num_rays=200,
-	                      do_fast=False,
-	                      is_antiphased=True,
-	                      atm_ext="Num4D",
-	                      prefix='s')
+                            values={'super_temperature': derive()},
+                            symmetry=True,
+                            omit=False,
+                            cede=False,
+                            concentric=False,
+                            sqrt_num_cells=32,
+                            min_sqrt_num_cells=10,
+                            max_sqrt_num_cells=100,
+                            num_leaves=100,
+                            num_rays=200,
+                            do_fast=False,
+                            is_antiphased=True,
+                            atm_ext="Num4D",
+                            image_order_limit=3,
+                            prefix='s')
 
 
 from xpsi import HotRegions
@@ -485,11 +487,9 @@ class CustomPrior(xpsi.Prior):
 
         ref = self.parameters.star.spacetime # shortcut
 
-        # limit polar radius to try to exclude deflections >= \pi radians
-        # due to oblateness this does not quite eliminate all configurations
-        # with deflections >= \pi radians
+        # limit polar radius to be outside the Schwarzschild photon sphere
         R_p = 1.0 + ref.epsilon * (-0.788 + 1.030 * ref.zeta)
-        if R_p < 1.76 / ref.R_r_s:
+        if R_p < 1.505 / ref.R_r_s:
             return -np.inf
 
         # polar radius at photon sphere for ~static star (static ambient spacetime)

--- a/examples/examples_modeling_tutorial/TestRun_NumBeam.py
+++ b/examples/examples_modeling_tutorial/TestRun_NumBeam.py
@@ -140,6 +140,7 @@ primary =  CustomHotRegion(bounds=bounds,
                             num_rays=200,
                             fbeam=True,
                             atm_ext="Num4D",
+                            image_order_limit=3,
                             beam_opt=2,
                             prefix='p')
               	                    
@@ -198,6 +199,7 @@ secondary =  CustomHotRegion(bounds=bounds,
                             is_antiphased=True,
                             fbeam=True,
                             atm_ext="Num4D",
+                            image_order_limit=3,
                             beam_opt=2,
                             prefix='s')	                      
 
@@ -450,11 +452,9 @@ class CustomPrior(xpsi.Prior):
 
         ref = self.parameters.star.spacetime # shortcut
 
-        # limit polar radius to try to exclude deflections >= \pi radians
-        # due to oblateness this does not quite eliminate all configurations
-        # with deflections >= \pi radians
+        # limit polar radius to be outside the Schwarzschild photon sphere
         R_p = 1.0 + ref.epsilon * (-0.788 + 1.030 * ref.zeta)
-        if R_p < 1.76 / ref.R_r_s:
+        if R_p < 1.505 / ref.R_r_s:
             return -np.inf
 
         # polar radius at photon sphere for ~static star (static ambient spacetime)

--- a/examples/examples_modeling_tutorial/TestRun_Pol.py
+++ b/examples/examples_modeling_tutorial/TestRun_Pol.py
@@ -34,18 +34,19 @@ bounds = dict(super_colatitude = (None, None),
               super_temperature = (5.1, 6.8))
 
 primary = xpsi.HotRegion(bounds=bounds,
-                            values={},
-                            symmetry=True,
-                            omit=False,
-                            cede=False,
-                            concentric=False,
-                            sqrt_num_cells=32,
-                            min_sqrt_num_cells=10,
-                            max_sqrt_num_cells=64,
-                            num_leaves=100,
-                            num_rays=200,
-                            atm_ext="Pol_BB_Burst",
-                            prefix='p')
+                        values={},
+                        symmetry=True,
+                        omit=False,
+                        cede=False,
+                        concentric=False,
+                        sqrt_num_cells=32,
+                        min_sqrt_num_cells=10,
+                        max_sqrt_num_cells=64,
+                        num_leaves=100,
+                        num_rays=200,
+                        atm_ext="Pol_BB_Burst",
+                        image_order_limit=3,
+                        prefix='p')
 
 bounds2 = dict(super_colatitude = (None, None),
                         super_radius = (None, None),
@@ -70,6 +71,7 @@ secondary = xpsi.HotRegion(bounds=bounds2, # can otherwise use same bounds
                             do_fast=False,
                             atm_ext="Pol_BB_Burst",
                             is_antiphased=True,
+                            image_order_limit=3,
                             prefix='s')
 
 

--- a/examples/examples_modeling_tutorial/TestRun_PolNum_split_1spot.py
+++ b/examples/examples_modeling_tutorial/TestRun_PolNum_split_1spot.py
@@ -221,18 +221,19 @@ bounds = dict(super_colatitude = (None, None),
               super_te = (40.0, 200.0))
 
 primary = CustomHotRegion_Accreting(bounds=bounds,
-                            values={},
-                            symmetry=True,
-                            omit=False,
-                            cede=False,
-                            concentric=False,
-                            sqrt_num_cells=32, #100
-                            min_sqrt_num_cells=10,
-                            max_sqrt_num_cells=64, #100
-                            num_leaves=100,
-                            num_rays=200,
-                            split=True,
-                            prefix='p')
+                                    values={},
+                                    symmetry=True,
+                                    omit=False,
+                                    cede=False,
+                                    concentric=False,
+                                    sqrt_num_cells=32, #100
+                                    min_sqrt_num_cells=10,
+                                    max_sqrt_num_cells=64, #100
+                                    num_leaves=100,
+                                    num_rays=200,
+                                    split=True,
+                                    image_order_limit=3,
+                                    prefix='p')
 
 from xpsi import HotRegions
 hot = HotRegions((primary,))

--- a/examples/examples_modeling_tutorial/TestRun_PolNum_split_inference.py
+++ b/examples/examples_modeling_tutorial/TestRun_PolNum_split_inference.py
@@ -435,18 +435,19 @@ bounds = dict(super_colatitude = (None, None),
               super_te = (40.0, 200.0))
 
 primary = CustomHotRegion_Accreting(bounds=bounds,
-                            values={},
-                            symmetry=True,
-                            omit=False,
-                            cede=False,
-                            concentric=False,
-                            sqrt_num_cells=32, #100
-                            min_sqrt_num_cells=10,
-                            max_sqrt_num_cells=64, #100
-                            num_leaves=100,
-                            num_rays=200,
-                            split=True,
-                            prefix='p')
+                                    values={},
+                                    symmetry=True,
+                                    omit=False,
+                                    cede=False,
+                                    concentric=False,
+                                    sqrt_num_cells=32, #100
+                                    min_sqrt_num_cells=10,
+                                    max_sqrt_num_cells=64, #100
+                                    num_leaves=100,
+                                    num_rays=200,
+                                    split=True,
+                                    image_order_limit=3,
+                                    prefix='p')
 
 bounds2 = dict(super_colatitude = (None, None),
                         super_radius = (None, None),
@@ -462,20 +463,21 @@ bounds2 = dict(super_colatitude = (None, None),
                         cede_te = (40.0, 200.0))
 
 secondary = CustomHotRegion_Accreting(bounds=bounds2, # can otherwise use same bounds
-                            values={},
-                            symmetry=True,
-                            omit=False,
-                            cede=True,
-                            concentric=False,
-                            sqrt_num_cells=32,
-                            min_sqrt_num_cells=10,
-                            max_sqrt_num_cells=100,
-                            num_leaves=100,
-                            num_rays=200,
-                            do_fast=False,
-                            is_antiphased=True,
-                            split=True,
-                            prefix='s')
+                                    values={},
+                                    symmetry=True,
+                                    omit=False,
+                                    cede=True,
+                                    concentric=False,
+                                    sqrt_num_cells=32,
+                                    min_sqrt_num_cells=10,
+                                    max_sqrt_num_cells=100,
+                                    num_leaves=100,
+                                    num_rays=200,
+                                    do_fast=False,
+                                    is_antiphased=True,
+                                    split=True,
+                                    image_order_limit=3,
+                                    prefix='s')
 
 
 from xpsi import HotRegions
@@ -642,11 +644,9 @@ class CustomPrior(xpsi.Prior):
 
         ref = self.parameters.star.spacetime # shortcut
 
-        # limit polar radius to try to exclude deflections >= \pi radians
-        # due to oblateness this does not quite eliminate all configurations
-        # with deflections >= \pi radians
+        # limit polar radius to be outside the Schwarzschild photon sphere
         R_p = 1.0 + ref.epsilon * (-0.788 + 1.030 * ref.zeta)
-        if R_p < 1.76 / ref.R_r_s:
+        if R_p < 1.505 / ref.R_r_s:
             return -np.inf
 
         mu = math.sqrt(-1.0 / (3.0 * ref.epsilon * (-0.788 + 1.030 * ref.zeta)))


### PR DESCRIPTION
X-PSI example scripts udpated to allow same compactness as commonly allowed for NICER analyses and the commonly used multiple imaging restrictions added.

In addition, a comment added to Synthesise notebook on how to save synthetic data without noise if interested (rounding the numbers to nearest integer in this example).