### PR TITLE
389 implement split atmosphere interpolation for 4 dimensional atmospheres

### DIFF
--- a/examples/examples_modeling_tutorial/TestRun_AMXP.py
+++ b/examples/examples_modeling_tutorial/TestRun_AMXP.py
@@ -68,7 +68,7 @@ primary = CustomHotRegion_Accreting(bounds=bounds,
                                     max_sqrt_num_cells=64, #100
                                     num_leaves=num_leaves,
                                     num_rays=200,
-                                    split=True,
+                                    split=False,
                                     atm_ext='Num5D',
                                     image_order_limit=3,
                                     prefix='p')

--- a/examples/examples_modeling_tutorial/TestRun_AMXP.py
+++ b/examples/examples_modeling_tutorial/TestRun_AMXP.py
@@ -68,7 +68,7 @@ primary = CustomHotRegion_Accreting(bounds=bounds,
                                     max_sqrt_num_cells=64, #100
                                     num_leaves=num_leaves,
                                     num_rays=200,
-                                    split=False,
+                                    split=True,
                                     atm_ext='Num5D',
                                     image_order_limit=3,
                                     prefix='p')

--- a/examples/examples_modeling_tutorial/TestRun_Num.py
+++ b/examples/examples_modeling_tutorial/TestRun_Num.py
@@ -617,13 +617,13 @@ runtime_params = {'resume': False,
                   'n_clustering_params': None,
                   'outputfiles_basename': './run/run_Num',
                   'n_iter_before_update': 50,
-                  'n_live_points': 50,
+                  'n_live_points': 10,
                   'sampling_efficiency': 0.8,
                   'const_efficiency_mode': False,
                   'wrapped_params': wrapped_params,
                   'evidence_tolerance': 0.5,
                   'seed': 7,
-                  'max_iter': 100, # manual termination condition for short test
+                  'max_iter': 1, # manual termination condition for short test
                   'verbose': True}
 
 # let's require that checks pass before starting to sample

--- a/examples/examples_modeling_tutorial/TestRun_Num_test.py
+++ b/examples/examples_modeling_tutorial/TestRun_Num_test.py
@@ -122,7 +122,7 @@ bounds = dict(super_colatitude = (None, None),
               phase_shift = (0.0, 0.1),
               super_temperature = (5.1, 6.8))
 
-split = True
+split = False
 
 primary = xpsi.HotRegion(bounds=bounds,
                         values={},
@@ -632,6 +632,8 @@ runtime_params = {'resume': False,
 
 # let's require that checks pass before starting to sample
 true_logl = -68147.0113542
+
+#likelihood(p)
 likelihood.check(None, [true_logl], 1.0e-2,physical_points=[p],force_update=True)
 
 if __name__ == '__main__': # sample from the posterior
@@ -647,9 +649,13 @@ if __name__ == '__main__': # sample from the posterior
     fig, ax = plt.subplots()
     CustomAxes.plot_bolometric_pulse(ax, np.linspace(0.0, 1.0, 33), signal.expected_counts)
     
+    fig, ax = plt.subplots()
+    profile = CustomAxes.plot_2D_counts(ax, signal.expected_counts, np.linspace(0.0, 1.0, 33), np.arange(20,202))
+    fig.colorbar(profile, ax=ax)
+    
     import time
     start = time.time()
-    multiple_times = 20
+    multiple_times = 100
     for i in range(multiple_times):
         photosphere.integrate(energies, threads=1) # the number of OpenMP threads to use
 

--- a/examples/examples_modeling_tutorial/TestRun_Num_test.py
+++ b/examples/examples_modeling_tutorial/TestRun_Num_test.py
@@ -1,0 +1,642 @@
+'''
+Test script to check that X-PSI installation is working (with the numerical atmosphere extension).
+The run is succesful if it passes the likelihood check (in ~ 1 minute) and sampling finishes without errors (in ~ 5 min).
+The model and synthetic data are based on those shown in the Modelling tutorial notebook.
+
+Prequisities:
+Before running the script, add the NICER instrument files to the model_data subdirectory:
+nicer_v1.01_arf.txt, nicer_v1.01_rmf_energymap.txt, and nicer_v1.01_rmf_matrix.txt, nsx_H_v200804.out
+(found from https://doi.org/10.5281/zenodo.7094144).
+'''
+
+
+
+import os
+import numpy as np
+import math
+import time
+
+from matplotlib import pyplot as plt
+from matplotlib import rcParams
+from matplotlib.ticker import MultipleLocator, AutoLocator, AutoMinorLocator
+from matplotlib import gridspec
+from matplotlib import cm
+
+import xpsi
+
+from xpsi.global_imports import _c, _G, _dpr, gravradius, _csq, _km, _2pi
+
+np.random.seed(xpsi._rank+10)
+
+print('Rank reporting: %d' % xpsi._rank)
+
+#using an example synthetic data
+settings = dict(counts = np.loadtxt('model_data/example_synthetic_realisation.dat', dtype=np.double),
+        channels=np.arange(20,201),
+        phases=np.linspace(0.0, 1.0, 33),
+        first=0, last=180,
+        exposure_time=984307.6661)
+data = xpsi.Data(**settings)
+
+class CustomInstrument(xpsi.Instrument):
+    """ A model of the NICER telescope response. """
+
+    def __call__(self, signal, *args):
+        """ Overwrite base just to show it is possible.
+
+        We loaded only a submatrix of the total instrument response
+        matrix into memory, so here we can simplify the method in the
+        base class.
+
+        """
+        matrix = self.construct_matrix()
+
+        self._folded_signal = np.dot(matrix, signal)
+
+        return self._folded_signal
+
+    @classmethod
+    def from_response_files(cls, ARF, RMF, channel_edges, max_input,
+                            min_input=0):
+        """ Constructor which converts response files into :class:`numpy.ndarray`s.
+        :param str ARF: Path to ARF which is compatible with
+                                :func:`numpy.loadtxt`.
+        :param str RMF: Path to RMF which is compatible with
+                                :func:`numpy.loadtxt`.
+        :param str channel_edges:  Path to edges which is compatible with
+                                  :func:`numpy.loadtxt`.
+        """
+        link ="https://doi.org/10.5281/zenodo.7094144"
+        if min_input != 0:
+            min_input = int(min_input)
+
+        max_input = int(max_input)
+
+        try:
+            ARF = np.loadtxt(ARF, dtype=np.double, skiprows=3)
+        except:
+            print("ERROR: You miss the following file: {}\nThe file is found from here: {}".format(ARF, link))
+            exit()
+
+        try:
+            RMF = np.loadtxt(RMF, dtype=np.double)
+        except:
+            print("ERROR: You miss the following file: {}\nThe file is found from here: {}".format(RMF, link))
+            exit()
+
+        try:
+            channel_edges = np.loadtxt(channel_edges, dtype=np.double, skiprows=3)[:,1:]
+        except:
+            print("ERROR: You miss the following file: {}\nThe file is found from here: {}".format(channel_edges, link))
+            exit()
+
+        matrix = np.ascontiguousarray(RMF[min_input:max_input,20:201].T, dtype=np.double)
+
+        edges = np.zeros(ARF[min_input:max_input,3].shape[0]+1, dtype=np.double)
+
+        edges[0] = ARF[min_input,1]; edges[1:] = ARF[min_input:max_input,2]
+
+        for i in range(matrix.shape[0]):
+            matrix[i,:] *= ARF[min_input:max_input,3]
+
+        channels = np.arange(20, 201)
+
+        return cls(matrix, edges, channels, channel_edges[20:202,-2])
+
+
+
+NICER = CustomInstrument.from_response_files(ARF = 'model_data/nicer_v1.01_arf.txt',
+                                             RMF = 'model_data/nicer_v1.01_rmf_matrix.txt',
+                                             channel_edges = 'model_data/nicer_v1.01_rmf_energymap.txt',
+                                             max_input = 500,
+                                             min_input = 0)
+
+bounds = dict(distance = (0.1, 1.0),                     # (Earth) distance
+                mass = (1.0, 3.0),                       # mass
+                radius = (3.0 * gravradius(1.0), 16.0),  # equatorial radius
+                cos_inclination = (0.0, 1.0))      # (Earth) inclination to rotation axis
+
+spacetime = xpsi.Spacetime(bounds=bounds, values=dict(frequency=300.0))
+
+bounds = dict(super_colatitude = (None, None),
+              super_radius = (None, None),
+              phase_shift = (0.0, 0.1),
+              super_temperature = (5.1, 6.8))
+
+primary = xpsi.HotRegion(bounds=bounds,
+                        values={},
+                        symmetry=True,
+                        omit=False,
+                        cede=False,
+                        concentric=False,
+                        sqrt_num_cells=32,
+                        min_sqrt_num_cells=10,
+                        max_sqrt_num_cells=64,
+                        num_leaves=100,
+                        num_rays=200,
+                        atm_ext="Num4D",
+                        image_order_limit=3,
+                        prefix='p')
+
+class derive(xpsi.Derive):
+    def __init__(self):
+        """
+        We can pass a reference to the primary here instead
+        and store it as an attribute if there is risk of
+        the global variable changing.
+
+        This callable can for this simple case also be
+        achieved merely with a function instead of a magic
+        method associated with a class.
+        """
+        pass
+
+    def __call__(self, boundto, caller = None):
+        # one way to get the required reference
+        global primary # unnecessary, but for clarity
+        return primary['super_temperature'] - 0.2
+
+
+bounds['super_temperature'] = None # declare fixed/derived variable
+
+secondary = xpsi.HotRegion(bounds=bounds, # can otherwise use same bounds
+                            values={'super_temperature': derive()},
+                            symmetry=True,
+                            omit=False,
+                            cede=False,
+                            concentric=False,
+                            sqrt_num_cells=32,
+                            min_sqrt_num_cells=10,
+                            max_sqrt_num_cells=100,
+                            num_leaves=100,
+                            num_rays=200,
+                            do_fast=False,
+                            is_antiphased=True,
+                            atm_ext="Num4D",
+                            image_order_limit=3,
+                            prefix='s')
+
+
+from xpsi import HotRegions
+hot = HotRegions((primary, secondary))
+h = hot.objects[0]
+hot['p__super_temperature'] = 6.0 # equivalent to ``primary['super_temperature'] = 6.0``
+
+
+use_elsewhere = False
+
+if use_elsewhere:
+    bounds=dict(elsewhere_temperature = (5.2, 6.5))
+
+    elsewhere = xpsi.Elsewhere(bounds=bounds,
+                   values={},
+                   sqrt_num_cells=512,
+                   num_rays=512,
+                   atm_ext="Num4D")
+else:
+    elsewhere = None
+
+class CustomPhotosphere_num(xpsi.Photosphere):
+    """ A photosphere extension to preload the numerical atmosphere NSX. """
+
+    @xpsi.Photosphere.hot_atmosphere.setter
+    def hot_atmosphere_old(self, path):
+        try:
+            NSX = np.loadtxt(path, dtype=np.double)
+        except:
+            print("ERROR: You miss the following file:", path)
+            print("The file is found from here: https://doi.org/10.5281/zenodo.7094144")
+            exit()
+        logT = np.zeros(35)
+        logg = np.zeros(14)
+        mu = np.zeros(67)
+        logE = np.zeros(166)
+
+        #reorder_buf = np.zeros((35,11,67,166))
+        reorder_buf = np.zeros((35,14,67,166))
+
+        index = 0
+        for i in range(reorder_buf.shape[0]):
+            for j in range(reorder_buf.shape[1]):
+                for k in range(reorder_buf.shape[3]):
+                   for l in range(reorder_buf.shape[2]):
+                        logT[i] = NSX[index,3]
+                        logg[j] = NSX[index,4]
+                        logE[k] = NSX[index,0]
+                        mu[reorder_buf.shape[2] - l - 1] = NSX[index,1]
+                        reorder_buf[i,j,reorder_buf.shape[2] - l - 1,k] = 10.0**(NSX[index,2])
+                        index += 1
+
+        buf = np.zeros(np.prod(reorder_buf.shape))
+
+        bufdex = 0
+        for i in range(reorder_buf.shape[0]):
+            for j in range(reorder_buf.shape[1]):
+                for k in range(reorder_buf.shape[2]):
+                   for l in range(reorder_buf.shape[3]):
+                        buf[bufdex] = reorder_buf[i,j,k,l]; bufdex += 1
+
+        self._hot_atmosphere = (logT, logg, mu, logE, buf)
+
+    @xpsi.Photosphere.hot_atmosphere.setter
+    def hot_atmosphere(self,path):
+        size=(35, 14, 67, 166)
+        path_npy = path[0:len(path)-3]+"npy"
+        try:
+            NSX = np.load(path_npy)
+        except:
+            try:
+                NSX = np.loadtxt(path, dtype=np.double)
+            except:
+                print("ERROR: You miss the following file:", path)
+                print("The file is found from here: https://doi.org/10.5281/zenodo.7094144")
+                exit()
+            np.save(path_npy,NSX)
+
+        def reorder_23(array, size):
+            new_array=np.zeros(size)
+            index=0
+            for i in range(size[3]):
+                 for j in range(size[2]):
+                      new_array[:,:,j,i]=array[:,:,index]
+                      index+=1
+            return new_array
+
+        _mu_opt = np.ascontiguousarray(NSX[0:size[2],1][::-1])
+        logE_opt = np.ascontiguousarray([NSX[i*size[2],0] for i in range(size[3])])
+        logT_opt = np.ascontiguousarray([NSX[i*size[1]*size[2]*size[3],3] for i in range(size[0])])
+        logg_opt = np.ascontiguousarray([NSX[i*size[2]*size[3],4] for i in range(size[1])])
+
+        reorder_buf_opt=reorder_23(10**NSX[:,2].reshape(size[0],size[1],int(np.prod(size)/(size[0]*size[1]))),size)
+        buf_opt=np.ravel(np.flip(reorder_buf_opt,2))
+
+        self._hot_atmosphere = (logT_opt, logg_opt, _mu_opt, logE_opt, buf_opt)
+
+    @xpsi.Photosphere.elsewhere_atmosphere.setter
+    def elsewhere_atmosphere(self,path):
+        size=(35, 14, 67, 166)
+        path_npy = path[0:len(path)-3]+"npy"
+        try:
+            NSX = np.load(path_npy)
+        except:
+            try:
+                NSX = np.loadtxt(path, dtype=np.double)
+            except:
+                print("ERROR: You miss the following file:", path)
+                print("The file is found from here: https://doi.org/10.5281/zenodo.7094144")
+                exit()
+            np.save(path_npy,NSX)
+
+        def reorder_23(array, size):
+            new_array=np.zeros(size)
+            index=0
+            for i in range(size[3]):
+                 for j in range(size[2]):
+                      new_array[:,:,j,i]=array[:,:,index]
+                      index+=1
+            return new_array
+
+        _mu_opt = np.ascontiguousarray(NSX[0:size[2],1][::-1])
+        logE_opt = np.ascontiguousarray([NSX[i*size[2],0] for i in range(size[3])])
+        logT_opt = np.ascontiguousarray([NSX[i*size[1]*size[2]*size[3],3] for i in range(size[0])])
+        logg_opt = np.ascontiguousarray([NSX[i*size[2]*size[3],4] for i in range(size[1])])
+
+        reorder_buf_opt=reorder_23(10**NSX[:,2].reshape(size[0],size[1],int(np.prod(size)/(size[0]*size[1]))),size)
+        buf_opt=np.ravel(np.flip(reorder_buf_opt,2))
+
+        self._elsewhere_atmosphere = (logT_opt, logg_opt, _mu_opt, logE_opt, buf_opt)
+
+
+photosphere = CustomPhotosphere_num(hot = hot, elsewhere = elsewhere,
+                                values=dict(mode_frequency = spacetime['frequency']))
+
+from time import time
+start_original = time()
+
+photosphere.hot_atmosphere = 'model_data/nsx_H_v200804.out'
+# #nsx_H_v171019.out'
+if use_elsewhere:
+    photosphere.elsewhere_atmosphere = 'model_data/nsx_H_v200804.out'
+
+done_original = time()
+print('Time taken by photosphere loading =', done_original-start_original)
+
+photosphere['mode_frequency'] == spacetime['frequency']
+
+star = xpsi.Star(spacetime = spacetime, photospheres = photosphere)
+
+print("Parameters of the star:")
+print(star.params)
+
+if use_elsewhere:
+    p = [1.0368513939430604,
+         6.087862992320039,
+         0.26870812456714116,
+         0.39140510783272897,
+         0.04346870860640872,
+         0.8002010406881243,
+         1.1165398710637626,
+         5.865655057483478,
+         0.07360477761463673,
+         2.4602238829718432,
+         0.4277092192054918,
+         5.5]
+else:
+    p = [1.0368513939430604,
+         6.087862992320039,
+         0.26870812456714116,
+         0.39140510783272897,
+         0.04346870860640872,
+         0.8002010406881243,
+         1.1165398710637626,
+         5.865655057483478,
+         0.07360477761463673,
+         2.4602238829718432,
+         0.4277092192054918]
+star(p)
+star.update()
+
+#To get the incident signal before interstellar absorption or operating with the telescope:
+energies = np.logspace(-1.0, np.log10(3.0), 128, base=10.0)
+photosphere.integrate(energies, threads=1) # the number of OpenMP threads to use
+print("Bolometric pulse for 1st spot:")
+print(repr(np.sum(photosphere.signal[0][0], axis=0)))
+print("Bolometric pulse for 2nd spot:")
+print(repr(np.sum(photosphere.signal[1][0], axis=0)))
+
+from xpsi.likelihoods.default_background_marginalisation import eval_marginal_likelihood
+from xpsi.likelihoods.default_background_marginalisation import precomputation
+
+class CustomSignal(xpsi.Signal):
+    """ A custom calculation of the logarithm of the likelihood.
+
+    We extend the :class:`xpsi.Signal.Signal` class to make it callable.
+
+    We overwrite the body of the __call__ method. The docstring for the
+    abstract method is copied.
+
+    """
+
+    def __init__(self, workspace_intervals = 1000, epsabs = 0, epsrel = 1.0e-8,
+                 epsilon = 1.0e-3, sigmas = 10.0, support = None, *args, **kwargs):
+        """ Perform precomputation. """
+
+        super(CustomSignal, self).__init__(*args, **kwargs)
+
+        try:
+            self._precomp = precomputation(self._data.counts.astype(np.int32))
+        except AttributeError:
+            print('No data... can synthesise data but cannot evaluate a '
+                  'likelihood function.')
+        else:
+            self._workspace_intervals = workspace_intervals
+            self._epsabs = epsabs
+            self._epsrel = epsrel
+            self._epsilon = epsilon
+            self._sigmas = sigmas
+
+            if support is not None:
+                self._support = support
+            else:
+                self._support = -1.0 * np.ones((self._data.counts.shape[0],2))
+                self._support[:,0] = 0.0
+
+    @property
+    def support(self):
+        return self._support
+
+    @support.setter
+    def support(self, obj):
+        self._support = obj
+
+    def __call__(self, *args, **kwargs):
+        self.loglikelihood, self.expected_counts, self.background_signal, self.background_signal_given_support = \
+                eval_marginal_likelihood(self._data.exposure_time,
+                                          self._data.phases,
+                                          self._data.counts,
+                                          self._signals,
+                                          self._phases,
+                                          self._shifts,
+                                          self._precomp,
+                                          self._support,
+                                          self._workspace_intervals,
+                                          self._epsabs,
+                                          self._epsrel,
+                                          self._epsilon,
+                                          self._sigmas,
+                                          kwargs.get('llzero'))
+
+
+signal = CustomSignal(data = data,
+                        instrument = NICER,
+                        background = None,
+                        interstellar = None,
+                        workspace_intervals = 1000,
+                        cache = True,
+                        epsrel = 1.0e-8,
+                        epsilon = 1.0e-3,
+                        sigmas = 10.0,
+                        support = None)
+
+from scipy.stats import truncnorm
+class CustomPrior(xpsi.Prior):
+    """ A custom (joint) prior distribution.
+
+    Source: Fictitious
+    Model variant: ST-U
+        Two single-temperature, simply-connected circular hot regions with
+        unshared parameters.
+
+    """
+
+    __derived_names__ = ['compactness', 'phase_separation',]
+    __draws_from_support__ = 3
+
+    def __init__(self):
+        """ Nothing to be done.
+
+        A direct reference to the spacetime object could be put here
+        for use in __call__:
+
+        .. code-block::
+
+            self.spacetime = ref
+
+        Instead we get a reference to the spacetime object through the
+        a reference to a likelihood object which encapsulates a
+        reference to the spacetime object.
+
+        """
+        super(CustomPrior, self).__init__() # not strictly required if no hyperparameters
+
+    def __call__(self, p = None):
+        """ Evaluate distribution at ``p``.
+
+        :param list p: Model parameter values.
+
+        :returns: Logarithm of the distribution evaluated at ``p``.
+
+        """
+        temp = super(CustomPrior, self).__call__(p)
+        if not np.isfinite(temp):
+            return temp
+
+        # based on contemporary EOS theory
+        if not self.parameters['radius'] <= 16.0:
+            return -np.inf
+
+        ref = self.parameters.star.spacetime # shortcut
+
+        # limit polar radius to be outside the Schwarzschild photon sphere
+        R_p = 1.0 + ref.epsilon * (-0.788 + 1.030 * ref.zeta)
+        if R_p < 1.505 / ref.R_r_s:
+            return -np.inf
+
+        # polar radius at photon sphere for ~static star (static ambient spacetime)
+        #if R_p < 1.5 / ref.R_r_s:
+        #    return -np.inf
+
+        mu = math.sqrt(-1.0 / (3.0 * ref.epsilon * (-0.788 + 1.030 * ref.zeta)))
+
+        # 2-surface cross-section have a single maximum in |z|
+        # i.e., an elliptical surface; minor effect on support, if any,
+        # for high spin frequenies
+        if mu < 1.0:
+            return -np.inf
+
+        ref = self.parameters # redefine shortcut
+
+        # enforce order in hot region colatitude
+        if ref['p__super_colatitude'] > ref['s__super_colatitude']:
+            return -np.inf
+
+        phi = (ref['p__phase_shift'] - 0.5 - ref['s__phase_shift']) * _2pi
+
+        ang_sep = xpsi.HotRegion.psi(ref['s__super_colatitude'],
+                                     phi,
+                                     ref['p__super_colatitude'])
+
+        # hot regions cannot overlap
+        if ang_sep < ref['p__super_radius'] + ref['s__super_radius']:
+            return -np.inf
+
+	#print("Calling CustomPrior with these paremeters:",p)
+
+        return 0.0
+
+    def inverse_sample(self, hypercube=None):
+        """ Draw sample uniformly from the distribution via inverse sampling. """
+
+        to_cache = self.parameters.vector
+
+        if hypercube is None:
+            hypercube = np.random.rand(len(self))
+
+        # the base method is useful, so to avoid writing that code again:
+        _ = super(CustomPrior, self).inverse_sample(hypercube)
+
+        ref = self.parameters # shortcut
+
+        idx = ref.index('distance')
+        ref['distance'] = truncnorm.ppf(hypercube[idx], -2.0, 7.0, loc=0.3, scale=0.1)
+
+        # flat priors in cosine of hot region centre colatitudes (isotropy)
+        # support modified by no-overlap rejection condition
+        idx = ref.index('p__super_colatitude')
+        a, b = ref.get_param('p__super_colatitude').bounds
+        a = math.cos(a); b = math.cos(b)
+        ref['p__super_colatitude'] = math.acos(b + (a - b) * hypercube[idx])
+
+        idx = ref.index('s__super_colatitude')
+        a, b = ref.get_param('s__super_colatitude').bounds
+        a = math.cos(a); b = math.cos(b)
+        ref['s__super_colatitude'] = math.acos(b + (a - b) * hypercube[idx])
+
+        # restore proper cache
+        for parameter, cache in zip(ref, to_cache):
+            parameter.cached = cache
+
+        # it is important that we return the desired vector because it is
+        # automatically written to disk by MultiNest and only by MultiNest
+        return self.parameters.vector
+
+    def transform(self, p, **kwargs):
+        """ A transformation for post-processing. """
+
+        p = list(p) # copy
+
+        # used ordered names and values
+        ref = dict(zip(self.parameters.names, p))
+
+        # compactness ratio M/R_eq
+        p += [gravradius(ref['mass']) / ref['radius']]
+
+        # phase separation between hot regions
+        # first some temporary variables:
+        if ref['p__phase_shift'] < 0.0:
+            temp_p = ref['p__phase_shift'] + 1.0
+        else:
+            temp_p = ref['p__phase_shift']
+
+        temp_s = 0.5 + ref['s__phase_shift']
+
+        if temp_s > 1.0:
+            temp_s = temp_s - 1.0
+
+        # now append:
+        if temp_s >= temp_p:
+            p += [temp_s - temp_p]
+        else:
+            p += [1.0 - temp_p + temp_s]
+
+        return p
+
+prior = CustomPrior()
+
+
+likelihood = xpsi.Likelihood(star = star, signals = signal,
+                             num_energies=128,
+                             threads=1,
+                             prior=prior,
+                             externally_updated=True)
+
+
+wrapped_params = [0]*len(likelihood)
+wrapped_params[likelihood.index('p__phase_shift')] = 1
+wrapped_params[likelihood.index('s__phase_shift')] = 1
+
+try:
+    os.makedirs("run")
+except OSError:
+    if not os.path.isdir("run"):
+        raise
+
+runtime_params = {'resume': False,
+                  'importance_nested_sampling': False,
+                  'multimodal': False,
+                  'n_clustering_params': None,
+                  'outputfiles_basename': './run/run_Num',
+                  'n_iter_before_update': 50,
+                  'n_live_points': 10,
+                  'sampling_efficiency': 0.8,
+                  'const_efficiency_mode': False,
+                  'wrapped_params': wrapped_params,
+                  'evidence_tolerance': 0.5,
+                  'seed': 7,
+                  'max_iter': 1, # manual termination condition for short test
+                  'verbose': True}
+
+# let's require that checks pass before starting to sample
+true_logl = -68147.0113542
+likelihood.check(None, [true_logl], 1.0e-6,physical_points=[p],force_update=True)
+
+if __name__ == '__main__': # sample from the posterior
+    #xpsi.Sample.nested(likelihood, prior,**runtime_params)
+    pulse_1 = photosphere.signal[0][0]
+    num_leaves = 100
+    phases = np.linspace(0,1,num_leaves)
+    from modules.helper_functions import CustomAxes
+    fig, ax = plt.subplots()
+    profile = CustomAxes.plot_2D_signal(ax, [pulse_1], phases, [0,0], energies, 'energies')
+    fig.colorbar(profile, ax=ax)
+    

--- a/examples/examples_modeling_tutorial/TestRun_Num_test.py
+++ b/examples/examples_modeling_tutorial/TestRun_Num_test.py
@@ -14,7 +14,6 @@ nicer_v1.01_arf.txt, nicer_v1.01_rmf_energymap.txt, and nicer_v1.01_rmf_matrix.t
 import os
 import numpy as np
 import math
-import time
 
 from matplotlib import pyplot as plt
 from matplotlib import rcParams
@@ -650,7 +649,7 @@ if __name__ == '__main__': # sample from the posterior
     
     import time
     start = time.time()
-    multiple_times = 100
+    multiple_times = 20
     for i in range(multiple_times):
         photosphere.integrate(energies, threads=1) # the number of OpenMP threads to use
 

--- a/setup.py
+++ b/setup.py
@@ -240,6 +240,7 @@ if __name__ == '__main__':
                 'xpsi.surface_radiation_field.hot_BB_burst',
                 'xpsi.surface_radiation_field.hot_Num2D',
                 'xpsi.surface_radiation_field.hot_Num2D_split',
+                'xpsi.surface_radiation_field.hot_Num4D_split',
                 'xpsi.surface_radiation_field.hot_Num5D_split',
                 'xpsi.surface_radiation_field.hot_wrapper',
                 'xpsi.surface_radiation_field.elsewhere_user',

--- a/xpsi/HotRegion.py
+++ b/xpsi/HotRegion.py
@@ -765,9 +765,6 @@ class HotRegion(ParameterSubspace):
             raise TypeError('Got an unrecognised atm_ext argument. Note that the only allowed '
                             'atmosphere options are at the moment "BB", "Num4D", "Pol_BB_Burst",'
                             '"Pol_Num2D", "Num5D", and "user".')
-        if self._split:
-            print('The default/given atmosphere option is ignored, since using split=True,'
-                  ' which only works with numerical 3+2D interpolation.')
 
     @property
     def beam_opt(self):
@@ -1174,6 +1171,9 @@ class HotRegion(ParameterSubspace):
             if hot_atmosphere == ():
                 raise AtmosError('The numerical atmosphere data were not preloaded, '
                                  'even though that is required by the current atmosphere extension.')
+
+        # print('atm_ext',self.atm_ext)
+        # print('hot_atmosphere',hot_atmosphere)
 
         super_pulse = self._integrator(threads,
                                        st.R,

--- a/xpsi/cellmesh/integratorIQU_for_azimuthal_invariance_split.pyx
+++ b/xpsi/cellmesh/integratorIQU_for_azimuthal_invariance_split.pyx
@@ -54,8 +54,8 @@ from xpsi.surface_radiation_field.hot_Num5D_split cimport (init_hot_Num5D,
                                                eval_hot_Num5D_Q,
                                                eval_hot_norm_Num5D,
                                                free_hot_Num5D,
-                                               produce_2D_data,
-                                               make_atmosphere_2D)
+                                               produce_2D_data_Num5D,
+                                               make_atmosphere_2D_Num5D)
 
 from xpsi.surface_radiation_field.hot_Num2D_split cimport (init_hot_2D,
                                                eval_hot_2D_I,
@@ -320,15 +320,15 @@ def integrate(size_t numThreads,
     cdef double* I_data_2D
     cdef double* Q_data_2D
 
-    I_data_2D = produce_2D_data(T, &(srcCellParams[0,0,0]), hot_data_I)
-    atmosphere_2D_I = make_atmosphere_2D(I_data_2D, hot_data_I)
+    I_data_2D = produce_2D_data_Num5D(T, &(srcCellParams[0,0,0]), hot_data_I)
+    atmosphere_2D_I = make_atmosphere_2D_Num5D(I_data_2D, hot_data_I)
 
     # initiate I data 2D
     hot_preloaded_2D_I = init_preload(atmosphere_2D_I)
     hot_data_2D_I = init_hot_2D(N_T, hot_preloaded_2D_I)
 
-    Q_data_2D = produce_2D_data(T, &(srcCellParams[0,0,0]), hot_data_Q)
-    atmosphere_2D_Q = make_atmosphere_2D(Q_data_2D, hot_data_Q)
+    Q_data_2D = produce_2D_data_Num5D(T, &(srcCellParams[0,0,0]), hot_data_Q)
+    atmosphere_2D_Q = make_atmosphere_2D_Num5D(Q_data_2D, hot_data_Q)
 
     # initiate Qdata 2D
     hot_preloaded_2D_Q = init_preload(atmosphere_2D_Q)

--- a/xpsi/cellmesh/integrator_for_azimuthal_invariance.pyx
+++ b/xpsi/cellmesh/integrator_for_azimuthal_invariance.pyx
@@ -54,6 +54,9 @@ from xpsi.surface_radiation_field.hot_wrapper cimport (init_hot,
                                                      eval_hot_I,
                                                      eval_hot_norm)
 
+
+from xpsi.surface_radiation_field.hot_Num4D_split cimport correct_E_NSX
+
 from xpsi.surface_radiation_field.elsewhere_wrapper cimport (init_elsewhere,
                                                      free_elsewhere,
                                                      eval_elsewhere,
@@ -442,9 +445,11 @@ def integrate(size_t numThreads,
                                     if hot_atm == 6:
                                         E_electronrest=E_prime*0.001956951 #kev to electron rest energy conversion
                                         E_prime = E_electronrest
+                                    elif hot_atm == 2:
+                                        E_prime = correct_E_NSX(srcCellParams[i,J,0], E_prime)
 
                                     # printf("__ABB: %.8e, \n", _ABB)
-                                    # printf("E_electronrest %.8e\n", E_electronrest)
+                                    # printf("E_prime %.8e\n", E_prime)
                                     # printf("srcCellParams[i,J,0] %.8e\n", srcCellParams[i,J,0])
                                     # printf("srcCellParams[i,J,1] %.8e\n", srcCellParams[i,J,1])
                                     # printf("srcCellParams[i,J,2] %.8e\n", srcCellParams[i,J,2])
@@ -457,6 +462,9 @@ def integrate(size_t numThreads,
                                                    &(srcCellParams[i,J,0]),
                                                    hot_data,
                                                    _beam_opt)
+                                    
+                                    if hot_atm == 2:
+                                        I_E = I_E * pow(10.0, 3.0 * srcCellParams[i,J,0])
                                     
                                     # printf("I_E = %.8e\n", I_E)
 

--- a/xpsi/cellmesh/integrator_for_azimuthal_invariance.pyx
+++ b/xpsi/cellmesh/integrator_for_azimuthal_invariance.pyx
@@ -54,9 +54,6 @@ from xpsi.surface_radiation_field.hot_wrapper cimport (init_hot,
                                                      eval_hot_I,
                                                      eval_hot_norm)
 
-
-from xpsi.surface_radiation_field.hot_Num4D_split cimport correct_E_NSX
-
 from xpsi.surface_radiation_field.elsewhere_wrapper cimport (init_elsewhere,
                                                      free_elsewhere,
                                                      eval_elsewhere,
@@ -442,11 +439,9 @@ def integrate(size_t numThreads,
                                 for p in range(N_E):
                                     E_prime = energies[p] / _Z
                                     
-                                    if hot_atm == 6:
-                                        E_electronrest=E_prime*0.001956951 #kev to electron rest energy conversion
-                                        E_prime = E_electronrest
-                                    elif hot_atm == 2:
-                                        E_prime = correct_E_NSX(srcCellParams[i,J,0], E_prime)
+                                    # if hot_atm == 6:
+                                    #     E_electronrest=E_prime*0.001956951 #kev to electron rest energy conversion
+                                    #     E_prime = E_electronrest
 
                                     # printf("__ABB: %.8e, \n", _ABB)
                                     # printf("E_prime %.8e\n", E_prime)
@@ -463,8 +458,6 @@ def integrate(size_t numThreads,
                                                    hot_data,
                                                    _beam_opt)
                                     
-                                    if hot_atm == 2:
-                                        I_E = I_E * pow(10.0, 3.0 * srcCellParams[i,J,0])
                                     
                                     # printf("I_E = %.8e\n", I_E)
 

--- a/xpsi/surface_radiation_field/hot_Num2D.pyx
+++ b/xpsi/surface_radiation_field/hot_Num2D.pyx
@@ -198,7 +198,7 @@ cdef double eval_hot_Num2D(size_t THREAD,
         double *I_CACHE = D.acc.INTENSITY_CACHE[THREAD]
         double *V_CACHE = D.acc.VEC_CACHE[THREAD]
         double vec[4]
-        double E_eff = k_B_over_keV * pow(10.0, VEC[0])
+        #double E_eff = k_B_over_keV * pow(10.0, VEC[0])
         int update_baseNode[4]
         int CACHE = 0
 
@@ -209,7 +209,7 @@ cdef double eval_hot_Num2D(size_t THREAD,
     #vec[2] = mu
     #vec[3] = log10(E / E_eff)
     vec[0] = mu
-    vec[1] = log10(E)    
+    vec[1] = E    
     
 
     while i < D.p.ndims:

--- a/xpsi/surface_radiation_field/hot_Num4D_split.pxd
+++ b/xpsi/surface_radiation_field/hot_Num4D_split.pxd
@@ -12,6 +12,6 @@ cdef void* init_hot_Num4D(size_t numThreads, const _preloaded *const preloaded) 
 
 cdef int free_hot_Num4D(size_t numThreads, void *const data) nogil
 
-cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const data) nogil
+cdef double* produce_2D_data_Num4D(size_t THREAD, const double *const VEC, void *const data) nogil
 
-cdef object make_atmosphere_2D(double *I_data, void *const data)
+cdef object make_atmosphere_2D_Num4D(double *I_data, void *const data)

--- a/xpsi/surface_radiation_field/hot_Num4D_split.pxd
+++ b/xpsi/surface_radiation_field/hot_Num4D_split.pxd
@@ -1,0 +1,17 @@
+from .preload cimport _preloaded
+
+cdef double eval_hot_Num4D(size_t THREAD,
+                     double E,
+                     double mu,
+                     const double *const VEC,
+                     void *const data) nogil
+
+cdef double eval_hot_norm_Num4D() nogil
+
+cdef void* init_hot_Num4D(size_t numThreads, const _preloaded *const preloaded) nogil
+
+cdef int free_hot_Num4D(size_t numThreads, void *const data) nogil
+
+cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const data) nogil
+
+cdef object make_atmosphere_2D(double *I_data, void *const data)

--- a/xpsi/surface_radiation_field/hot_Num4D_split.pxd
+++ b/xpsi/surface_radiation_field/hot_Num4D_split.pxd
@@ -15,5 +15,3 @@ cdef int free_hot_Num4D(size_t numThreads, void *const data) nogil
 cdef double* produce_2D_data_Num4D(size_t THREAD, const double *const VEC, void *const data) nogil
 
 cdef object make_atmosphere_2D_Num4D(double *I_data, const double *const VEC, void *const data)
-
-cdef double correct_E_NSX(double T, double E_input) nogil

--- a/xpsi/surface_radiation_field/hot_Num4D_split.pxd
+++ b/xpsi/surface_radiation_field/hot_Num4D_split.pxd
@@ -14,4 +14,6 @@ cdef int free_hot_Num4D(size_t numThreads, void *const data) nogil
 
 cdef double* produce_2D_data_Num4D(size_t THREAD, const double *const VEC, void *const data) nogil
 
-cdef object make_atmosphere_2D_Num4D(double *I_data, void *const data)
+cdef object make_atmosphere_2D_Num4D(double *I_data, const double *const VEC, void *const data)
+
+cdef double correct_E_NSX(double T, double E_input) nogil

--- a/xpsi/surface_radiation_field/hot_Num4D_split.pyx
+++ b/xpsi/surface_radiation_field/hot_Num4D_split.pyx
@@ -199,14 +199,13 @@ cdef double eval_hot_Num4D(size_t THREAD,
         double *I_CACHE = D.acc.INTENSITY_CACHE[THREAD]
         double *V_CACHE = D.acc.VEC_CACHE[THREAD]
         double vec[4]
-        # double E_eff = k_B_over_keV * pow(10.0, VEC[0])
+        double E_eff = k_B_over_keV * pow(10.0, VEC[0])
         int update_baseNode[4]
         int CACHE = 0
 
     vec[0] = VEC[0]
     vec[1] = VEC[1]
     vec[2] = mu
-    #vec[3] = log10(E / E_eff) # correction now happens in a separate function, so I removed this
     vec[3] = E
 
     while i < D.p.ndims:
@@ -342,7 +341,8 @@ cdef double eval_hot_Num4D(size_t THREAD,
 
     if I < 0.0:
         return 0.0
-    return I #* pow(10.0, 3.0 * vec[0])
+    return I
+
 
 cdef double eval_hot_norm_Num4D() nogil:
     # Source radiation field normalisation which is independent of the
@@ -401,16 +401,3 @@ cdef object make_atmosphere_2D_Num4D(double *I_data, const double *const VEC, vo
         #E_array[j] = correct_E_NSX(VEC[0], D.p.params[3][j])
     cdef tuple atmosphere_2D = (mu_array, E_array, I_array)
     return atmosphere_2D
-
-
-cdef double correct_E_NSX(double T, double E_input) nogil:
-    # printf('corrector!')
-    # printf("T %.8e, ", T)
-    # printf("E_input %.8e\n", E_input)
-    
-    cdef double E_eff = k_B_over_keV * pow(10.0, T)
-    cdef double E_corrected
-    E_corrected = log10(E_input / E_eff)
-    
-    # printf("E_corrected %.8e ", E_corrected)
-    return E_corrected

--- a/xpsi/surface_radiation_field/hot_Num4D_split.pyx
+++ b/xpsi/surface_radiation_field/hot_Num4D_split.pyx
@@ -1,0 +1,393 @@
+#cython: cdivision=True
+#cython: boundscheck=False
+#cython: nonecheck=False
+#cython: wraparound=False
+
+from libc.math cimport M_PI, sqrt, sin, cos, acos, log10, pow, exp, fabs
+from libc.stdio cimport printf, fopen, fclose, fread, FILE
+from GSL cimport gsl_isnan, gsl_isinf
+from libc.stdlib cimport malloc, free
+
+from xpsi.global_imports import _keV, _k_B, _h_keV
+
+cdef int SUCCESS = 0
+cdef int ERROR = 1
+
+cdef double erg = 1.0e-7
+cdef double k_B = _k_B
+cdef double keV = _keV
+cdef double h_keV = _h_keV
+cdef double k_B_over_keV = k_B / keV
+cdef int VERBOSE = 0
+
+ctypedef struct ACCELERATE:
+    size_t **BN                # base node for interpolation
+    double **node_vals
+    double **SPACE
+    double **DIFF
+    double **INTENSITY_CACHE
+    double **VEC_CACHE
+
+# Modify this struct if useful for the user-defined source radiation field.
+# Note that the members of DATA will be shared by all threads and are
+# statically allocated, whereas the members of ACCELERATE will point to
+# dynamically allocated memory, not shared by threads.
+
+ctypedef struct DATA:
+    const _preloaded *p
+    ACCELERATE acc
+
+#----------------------------------------------------------------------->>>
+# >>> User modifiable functions.
+# >>> Note that the user is entirely free to wrap thread-safe and
+# ... non-parallel external C routines from an external library.
+# >>> Thus the bodies of the following need not be written explicitly in
+# ... the Cython language.
+#----------------------------------------------------------------------->>>
+cdef void* init_hot_Num4D(size_t numThreads, const _preloaded *const preloaded) nogil:
+    # This function must match the free management routine free_hot()
+    # in terms of freeing dynamically allocated memory. This is entirely
+    # the user's responsibility to manage.
+    # Return NULL if dynamic memory is not required for the model
+
+    if preloaded == NULL :
+        printf("ERROR: The numerical atmosphere data were not preloaded, which are required by this extension.\n")
+
+    cdef DATA *D = <DATA*> malloc(sizeof(DATA))
+    D.p = preloaded
+
+    D.p.BLOCKS[0] = 64
+    D.p.BLOCKS[1] = 16
+    D.p.BLOCKS[2] = 4
+
+    cdef size_t T, i, j, k, l
+
+    D.acc.BN = <size_t**> malloc(numThreads * sizeof(size_t*))
+    D.acc.node_vals = <double**> malloc(numThreads * sizeof(double*))
+    D.acc.SPACE = <double**> malloc(numThreads * sizeof(double*))
+    D.acc.DIFF = <double**> malloc(numThreads * sizeof(double*))
+    D.acc.INTENSITY_CACHE = <double**> malloc(numThreads * sizeof(double*))
+    D.acc.VEC_CACHE = <double**> malloc(numThreads * sizeof(double*))
+
+    for T in range(numThreads):
+        D.acc.BN[T] = <size_t*> malloc(D.p.ndims * sizeof(size_t))
+        D.acc.node_vals[T] = <double*> malloc(2 * D.p.ndims * sizeof(double))
+        D.acc.SPACE[T] = <double*> malloc(4 * D.p.ndims * sizeof(double))
+        D.acc.DIFF[T] = <double*> malloc(4 * D.p.ndims * sizeof(double))
+        D.acc.INTENSITY_CACHE[T] = <double*> malloc(256 * sizeof(double))
+        D.acc.VEC_CACHE[T] = <double*> malloc(D.p.ndims * sizeof(double))
+        for i in range(D.p.ndims):
+            D.acc.BN[T][i] = 0
+            D.acc.VEC_CACHE[T][i] = D.p.params[i][1]
+            D.acc.node_vals[T][2*i] = D.p.params[i][1]
+            D.acc.node_vals[T][2*i + 1] = D.p.params[i][2]
+
+            j = 4*i
+
+            D.acc.SPACE[T][j] = 1.0 / (D.p.params[i][0] - D.p.params[i][1])
+            D.acc.SPACE[T][j] /= D.p.params[i][0] - D.p.params[i][2]
+            D.acc.SPACE[T][j] /= D.p.params[i][0] - D.p.params[i][3]
+
+            D.acc.SPACE[T][j + 1] = 1.0 / (D.p.params[i][1] - D.p.params[i][0])
+            D.acc.SPACE[T][j + 1] /= D.p.params[i][1] - D.p.params[i][2]
+            D.acc.SPACE[T][j + 1] /= D.p.params[i][1] - D.p.params[i][3]
+
+            D.acc.SPACE[T][j + 2] = 1.0 / (D.p.params[i][2] - D.p.params[i][0])
+            D.acc.SPACE[T][j + 2] /= D.p.params[i][2] - D.p.params[i][1]
+            D.acc.SPACE[T][j + 2] /= D.p.params[i][2] - D.p.params[i][3]
+
+            D.acc.SPACE[T][j + 3] = 1.0 / (D.p.params[i][3] - D.p.params[i][0])
+            D.acc.SPACE[T][j + 3] /= D.p.params[i][3] - D.p.params[i][1]
+            D.acc.SPACE[T][j + 3] /= D.p.params[i][3] - D.p.params[i][2]
+
+            D.acc.DIFF[T][j] = D.acc.VEC_CACHE[T][i] - D.p.params[i][1]
+            D.acc.DIFF[T][j] *= D.acc.VEC_CACHE[T][i] - D.p.params[i][2]
+            D.acc.DIFF[T][j] *= D.acc.VEC_CACHE[T][i] - D.p.params[i][3]
+
+            D.acc.DIFF[T][j + 1] = D.acc.VEC_CACHE[T][i] - D.p.params[i][0]
+            D.acc.DIFF[T][j + 1] *= D.acc.VEC_CACHE[T][i] - D.p.params[i][2]
+            D.acc.DIFF[T][j + 1] *= D.acc.VEC_CACHE[T][i] - D.p.params[i][3]
+
+            D.acc.DIFF[T][j + 2] = D.acc.VEC_CACHE[T][i] - D.p.params[i][0]
+            D.acc.DIFF[T][j + 2] *= D.acc.VEC_CACHE[T][i] - D.p.params[i][1]
+            D.acc.DIFF[T][j + 2] *= D.acc.VEC_CACHE[T][i] - D.p.params[i][3]
+
+            D.acc.DIFF[T][j + 3] = D.acc.VEC_CACHE[T][i] - D.p.params[i][0]
+            D.acc.DIFF[T][j + 3] *= D.acc.VEC_CACHE[T][i] - D.p.params[i][1]
+            D.acc.DIFF[T][j + 3] *= D.acc.VEC_CACHE[T][i] - D.p.params[i][2]
+
+    cdef double *address = NULL
+    # Cache intensity
+    for T in range(numThreads):
+        for i in range(4):
+            for j in range(4):
+                for k in range(4):
+                    for l in range(4):
+                        address = D.p.I + (D.acc.BN[T][0] + i) * D.p.S[0]
+                        address += (D.acc.BN[T][1] + j) * D.p.S[1]
+                        address += (D.acc.BN[T][2] + k) * D.p.S[2]
+                        address += D.acc.BN[T][3] + l
+                        D.acc.INTENSITY_CACHE[T][i * D.p.BLOCKS[0] + j * D.p.BLOCKS[1] + k * D.p.BLOCKS[2] + l] = address[0]
+
+    # Cast for generalised usage in integration routines
+    return <void*> D
+
+
+cdef int free_hot_Num4D(size_t numThreads, void *const data) nogil:
+    # This function must match the initialisation routine init_hot()
+    # in terms of freeing dynamically allocated memory. This is entirely
+    # the user's responsibility to manage.
+    # The void pointer must be appropriately cast before memory is freed --
+    # only the user can know this at compile time.
+    # Just use free(<void*> data) iff no memory was dynamically
+    # allocated in the function:
+    #   init_hot()
+    # because data is expected to be NULL in this case
+
+    cdef DATA *D = <DATA*> data
+
+    cdef size_t T
+
+    for T in range(numThreads):
+        free(D.acc.BN[T])
+        free(D.acc.node_vals[T])
+        free(D.acc.SPACE[T])
+        free(D.acc.DIFF[T])
+        free(D.acc.INTENSITY_CACHE[T])
+        free(D.acc.VEC_CACHE[T])
+
+    free(D.acc.BN)
+    free(D.acc.node_vals)
+    free(D.acc.SPACE)
+    free(D.acc.DIFF)
+    free(D.acc.INTENSITY_CACHE)
+    free(D.acc.VEC_CACHE)
+
+    free(D)
+
+    return SUCCESS
+
+#----------------------------------------------------------------------->>>
+# >>> Cubic polynomial interpolation.
+# >>> Improve acceleration properties... i.e. do not recompute numerical
+# ... weights or re-read intensities if not necessary.
+#----------------------------------------------------------------------->>>
+cdef double eval_hot_Num4D(size_t THREAD,
+                     double E,
+                     double mu,
+                     const double *const VEC,
+                     void *const data) nogil:
+    # Arguments:
+    # E = photon energy in keV
+    # mu = cosine of ray zenith angle (i.e., angle to surface normal)
+    # VEC = variables such as temperature, effective gravity, ...
+    # data = numerical model data required for intensity evaluation
+
+    # This function must cast the void pointer appropriately for use.
+    cdef DATA *D = <DATA*> data
+
+    cdef:
+        size_t i = 0, ii
+        double I = 0.0, temp
+        double *node_vals = D.acc.node_vals[THREAD]
+        size_t *BN = D.acc.BN[THREAD]
+        double *SPACE = D.acc.SPACE[THREAD]
+        double *DIFF = D.acc.DIFF[THREAD]
+        double *I_CACHE = D.acc.INTENSITY_CACHE[THREAD]
+        double *V_CACHE = D.acc.VEC_CACHE[THREAD]
+        double vec[4]
+        double E_eff = k_B_over_keV * pow(10.0, VEC[0])
+        int update_baseNode[4]
+        int CACHE = 0
+
+    vec[0] = VEC[0]
+    vec[1] = VEC[1]
+    vec[2] = mu
+    vec[3] = log10(E / E_eff)
+
+    while i < D.p.ndims:
+        # if parallel == 31:
+        #     printf("\nDimension: %d", <int>i)
+        update_baseNode[i] = 0
+        if vec[i] < node_vals[2*i] and BN[i] != 0:
+            # if parallel == 31:
+            #     printf("\nExecute block 1: %d", <int>i)
+            update_baseNode[i] = 1
+            while vec[i] < D.p.params[i][BN[i] + 1]:
+                # if parallel == 31:
+                #     printf("\n!")
+                #     printf("\nvec i: %.8e", vec[i])
+                #     printf("\nBase node: %d", <int>BN[i])
+                if BN[i] > 0:
+                    BN[i] -= 1
+                elif vec[i] <= D.p.params[i][0]:
+                    vec[i] = D.p.params[i][0]
+                    break
+                elif BN[i] == 0:
+                    break
+
+            node_vals[2*i] = D.p.params[i][BN[i] + 1]
+            node_vals[2*i + 1] = D.p.params[i][BN[i] + 2]
+
+            # if parallel == 31:
+            #     printf("\nEnd Block 1: %d", <int>i)
+
+        elif vec[i] > node_vals[2*i + 1] and BN[i] != D.p.N[i] - 4:
+            # if parallel == 31:
+            #     printf("\nExecute block 2: %d", <int>i)
+            update_baseNode[i] = 1
+            while vec[i] > D.p.params[i][BN[i] + 2]:
+                if BN[i] < D.p.N[i] - 4:
+                    BN[i] += 1
+                elif vec[i] >= D.p.params[i][D.p.N[i] - 1]:
+                    vec[i] = D.p.params[i][D.p.N[i] - 1]
+                    break
+                elif BN[i] == D.p.N[i] - 4:
+                    break
+
+            node_vals[2*i] = D.p.params[i][BN[i] + 1]
+            node_vals[2*i + 1] = D.p.params[i][BN[i] + 2]
+
+            # if parallel == 31:
+            #     printf("\nEnd Block 2: %d", <int>i)
+
+        # if parallel == 31:
+        #     printf("\nTry block 3: %d", <int>i)
+
+        if V_CACHE[i] != vec[i] or update_baseNode[i] == 1:
+            # if parallel == 31:
+            #     printf("\nExecute block 3: %d", <int>i)
+            ii = 4*i
+            DIFF[ii] = vec[i] - D.p.params[i][BN[i] + 1]
+            DIFF[ii] *= vec[i] - D.p.params[i][BN[i] + 2]
+            DIFF[ii] *= vec[i] - D.p.params[i][BN[i] + 3]
+
+            DIFF[ii + 1] = vec[i] - D.p.params[i][BN[i]]
+            DIFF[ii + 1] *= vec[i] - D.p.params[i][BN[i] + 2]
+            DIFF[ii + 1] *= vec[i] - D.p.params[i][BN[i] + 3]
+
+            DIFF[ii + 2] = vec[i] - D.p.params[i][BN[i]]
+            DIFF[ii + 2] *= vec[i] - D.p.params[i][BN[i] + 1]
+            DIFF[ii + 2] *= vec[i] - D.p.params[i][BN[i] + 3]
+
+            DIFF[ii + 3] = vec[i] - D.p.params[i][BN[i]]
+            DIFF[ii + 3] *= vec[i] - D.p.params[i][BN[i] + 1]
+            DIFF[ii + 3] *= vec[i] - D.p.params[i][BN[i] + 2]
+
+            V_CACHE[i] = vec[i]
+
+            # if parallel == 31:
+            #     printf("\nEnd block 3: %d", <int>i)
+
+        # if parallel == 31:
+        #     printf("\nTry block 4: %d", <int>i)
+
+        if update_baseNode[i] == 1:
+            # if parallel == 31:
+            #     printf("\nExecute block 4: %d", <int>i)
+            CACHE = 1
+            SPACE[ii] = 1.0 / (D.p.params[i][BN[i]] - D.p.params[i][BN[i] + 1])
+            SPACE[ii] /= D.p.params[i][BN[i]] - D.p.params[i][BN[i] + 2]
+            SPACE[ii] /= D.p.params[i][BN[i]] - D.p.params[i][BN[i] + 3]
+
+            SPACE[ii + 1] = 1.0 / (D.p.params[i][BN[i] + 1] - D.p.params[i][BN[i]])
+            SPACE[ii + 1] /= D.p.params[i][BN[i] + 1] - D.p.params[i][BN[i] + 2]
+            SPACE[ii + 1] /= D.p.params[i][BN[i] + 1] - D.p.params[i][BN[i] + 3]
+
+            SPACE[ii + 2] = 1.0 / (D.p.params[i][BN[i] + 2] - D.p.params[i][BN[i]])
+            SPACE[ii + 2] /= D.p.params[i][BN[i] + 2] - D.p.params[i][BN[i] + 1]
+            SPACE[ii + 2] /= D.p.params[i][BN[i] + 2] - D.p.params[i][BN[i] + 3]
+
+            SPACE[ii + 3] = 1.0 / (D.p.params[i][BN[i] + 3] - D.p.params[i][BN[i]])
+            SPACE[ii + 3] /= D.p.params[i][BN[i] + 3] - D.p.params[i][BN[i] + 1]
+            SPACE[ii + 3] /= D.p.params[i][BN[i] + 3] - D.p.params[i][BN[i] + 2]
+
+            # if parallel == 31:
+            #     printf("\nEnd block 4: %d", <int>i)
+
+        i += 1
+
+    cdef size_t j, k, l, INDEX, II, JJ, KK
+    cdef double *address = NULL
+    # Combinatorics over nodes of hypercube; weight cgs intensities
+    for i in range(4):
+        II = i * D.p.BLOCKS[0]
+        for j in range(4):
+            JJ = j * D.p.BLOCKS[1]
+            for k in range(4):
+                KK = k * D.p.BLOCKS[2]
+                for l in range(4):
+                    address = D.p.I + (BN[0] + i) * D.p.S[0]
+                    address += (BN[1] + j) * D.p.S[1]
+                    address += (BN[2] + k) * D.p.S[2]
+                    address += BN[3] + l
+
+                    temp = DIFF[i] * DIFF[4 + j] * DIFF[8 + k] * DIFF[12 + l]
+                    temp *= SPACE[i] * SPACE[4 + j] * SPACE[8 + k] * SPACE[12 + l]
+                    INDEX = II + JJ + KK + l
+                    if CACHE == 1:
+                        I_CACHE[INDEX] = address[0]
+                    I += temp * I_CACHE[INDEX]
+
+    #if gsl_isnan(I) == 1:
+        #printf("\nIntensity: NaN; Index [%d,%d,%d,%d] ",
+                #<int>BN[0], <int>BN[1], <int>BN[2], <int>BN[3])
+
+    #printf("\nBase-nodes [%d,%d,%d,%d] ",
+                #<int>BN[0], <int>BN[1], <int>BN[2], <int>BN[3])
+
+    if I < 0.0:
+        return 0.0
+    return I * pow(10.0, 3.0 * vec[0])
+
+cdef double eval_hot_norm_Num4D() nogil:
+    # Source radiation field normalisation which is independent of the
+    # parameters of the parametrised model -- i.e. cell properties, energy,
+    # and angle.
+    # Writing the normalisation here reduces the number of operations required
+    # during integration.
+    # The units of the specific intensity need to be J/cm^2/s/keV/steradian.
+
+    return erg / h_keV
+
+cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const data) nogil:
+    # interpolate data to make a 2D dataset with only E and mu
+    cdef DATA *D = <DATA*> data
+    
+    cdef size_t i, j
+    cdef double I_E
+
+    cdef double *I_data
+    I_data = <double*> malloc(sizeof(double*) * D.p.N[2] * D.p.N[3])
+
+    
+    for i in range(D.p.N[2]):
+        mu = D.p.params[2][i]
+        for j in range(D.p.N[3]):
+            E = D.p.params[3][j]
+
+            I_E = eval_hot(THREAD,
+                            E,
+                            mu,
+                            VEC,
+                            data)
+            index = i * D.p.N[3] + j
+            I_data[index] = I_E
+
+    return I_data
+
+cdef object make_atmosphere_2D(double *I_data, void *const data):
+    cdef DATA *D = <DATA*> data
+    cdef np.ndarray[double, ndim=1, mode="c"] mu_array = np.ascontiguousarray(np.empty(D.p.N[2], dtype=float))
+    cdef np.ndarray[double, ndim=1, mode="c"] E_array = np.ascontiguousarray(np.empty(D.p.N[3], dtype=float))
+    cdef np.ndarray[double, ndim=1, mode="c"] I_array = np.ascontiguousarray(np.empty(D.p.N[2]*D.p.N[3], dtype=float))
+    cdef size_t i, j, index
+    for i in range(D.p.N[2]):
+        mu_array[i] = D.p.params[2][i]
+        for j in range(D.p.N[3]):
+            index = i * D.p.N[3] + j
+            I_array[index] = I_data[index]
+    for j in range(D.p.N[3]):
+        E_array[j] = D.p.params[3][j]
+    cdef tuple atmosphere_2D = (mu_array, E_array, I_array)
+    return atmosphere_2D

--- a/xpsi/surface_radiation_field/hot_Num4D_split.pyx
+++ b/xpsi/surface_radiation_field/hot_Num4D_split.pyx
@@ -5,10 +5,13 @@
 
 from libc.math cimport M_PI, sqrt, sin, cos, acos, log10, pow, exp, fabs
 from libc.stdio cimport printf, fopen, fclose, fread, FILE
-from GSL cimport gsl_isnan, gsl_isinf
+# from GSL cimport gsl_isnan, gsl_isinf
 from libc.stdlib cimport malloc, free
 
 from xpsi.global_imports import _keV, _k_B, _h_keV
+
+import numpy as np
+cimport numpy as np
 
 cdef int SUCCESS = 0
 cdef int ERROR = 1
@@ -350,7 +353,7 @@ cdef double eval_hot_norm_Num4D() nogil:
 
     return erg / h_keV
 
-cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const data) nogil:
+cdef double* produce_2D_data_Num4D(size_t THREAD, const double *const VEC, void *const data) nogil:
     # interpolate data to make a 2D dataset with only E and mu
     cdef DATA *D = <DATA*> data
     
@@ -366,7 +369,7 @@ cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const
         for j in range(D.p.N[3]):
             E = D.p.params[3][j]
 
-            I_E = eval_hot(THREAD,
+            I_E = eval_hot_Num4D(THREAD,
                             E,
                             mu,
                             VEC,
@@ -376,7 +379,7 @@ cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const
 
     return I_data
 
-cdef object make_atmosphere_2D(double *I_data, void *const data):
+cdef object make_atmosphere_2D_Num4D(double *I_data, void *const data):
     cdef DATA *D = <DATA*> data
     cdef np.ndarray[double, ndim=1, mode="c"] mu_array = np.ascontiguousarray(np.empty(D.p.N[2], dtype=float))
     cdef np.ndarray[double, ndim=1, mode="c"] E_array = np.ascontiguousarray(np.empty(D.p.N[3], dtype=float))

--- a/xpsi/surface_radiation_field/hot_Num5D_split.pxd
+++ b/xpsi/surface_radiation_field/hot_Num5D_split.pxd
@@ -24,6 +24,6 @@ cdef void* init_hot_Num5D(size_t numThreads, const _preloaded *const preloaded) 
 
 cdef int free_hot_Num5D(size_t numThreads, void *const data) nogil
 
-cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const data) nogil
+cdef double* produce_2D_data_Num5D(size_t THREAD, const double *const VEC, void *const data) nogil
 
-cdef object make_atmosphere_2D(double *I_data, void *const data)
+cdef object make_atmosphere_2D_Num5D(double *I_data, void *const data)

--- a/xpsi/surface_radiation_field/hot_Num5D_split.pyx
+++ b/xpsi/surface_radiation_field/hot_Num5D_split.pyx
@@ -5,7 +5,7 @@
 
 from libc.math cimport M_PI, sqrt, sin, cos, acos, log10, pow, exp, fabs
 from libc.stdio cimport printf, fopen, fclose, fread, FILE
-#from GSL cimport gsl_isnan, gsl_isinf
+# from GSL cimport gsl_isnan, gsl_isinf
 from libc.stdlib cimport malloc, free
 
 from xpsi.global_imports import _keV, _k_B
@@ -373,7 +373,7 @@ cdef double eval_hot_norm_Num5D() nogil:
 
     return erg / 4.135667662e-18
 
-cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const data) nogil:
+cdef double* produce_2D_data_Num5D(size_t THREAD, const double *const VEC, void *const data) nogil:
     # interpolate data to make a 2D dataset with only E and mu
     cdef DATA *D = <DATA*> data
     
@@ -389,7 +389,7 @@ cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const
         for j in range(D.p.N[4]):
             E = D.p.params[4][j]
 
-            I_E = eval_hot(THREAD,
+            I_E = eval_hot_Num5D_I(THREAD,
                             E,
                             mu,
                             VEC,
@@ -399,7 +399,7 @@ cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const
 
     return I_data
 
-cdef object make_atmosphere_2D(double *I_data, void *const data):
+cdef object make_atmosphere_2D_Num5D(double *I_data, void *const data):
     cdef DATA *D = <DATA*> data
     cdef np.ndarray[double, ndim=1, mode="c"] mu_array = np.ascontiguousarray(np.empty(D.p.N[3], dtype=float))
     cdef np.ndarray[double, ndim=1, mode="c"] E_array = np.ascontiguousarray(np.empty(D.p.N[4], dtype=float))

--- a/xpsi/surface_radiation_field/hot_wrapper.pxd
+++ b/xpsi/surface_radiation_field/hot_wrapper.pxd
@@ -22,4 +22,4 @@ cdef int free_hot(size_t numThreads, void *const data) nogil
 
 cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const data) nogil
 
-cdef object make_atmosphere_2D(double *I_data, void *const data)
+cdef object make_atmosphere_2D(double *I_data, const double *const VEC, void *const data)

--- a/xpsi/surface_radiation_field/hot_wrapper.pxd
+++ b/xpsi/surface_radiation_field/hot_wrapper.pxd
@@ -19,3 +19,7 @@ cdef double eval_hot_norm() nogil
 cdef void* init_hot(size_t numThreads, const _preloaded *const preloaded, size_t atm_ext) nogil
 
 cdef int free_hot(size_t numThreads, void *const data) nogil
+
+cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const data) nogil
+
+cdef object make_atmosphere_2D(double *I_data, void *const data)

--- a/xpsi/surface_radiation_field/hot_wrapper.pxd
+++ b/xpsi/surface_radiation_field/hot_wrapper.pxd
@@ -23,3 +23,17 @@ cdef int free_hot(size_t numThreads, void *const data) nogil
 cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const data) nogil
 
 cdef object make_atmosphere_2D(double *I_data, const double *const VEC, void *const data)
+
+cdef void* init_hot_2D_split(size_t numThreads, const _preloaded *const preloaded) nogil
+    
+cdef int free_hot_2D_split(size_t numThreads, void *const data) nogil
+
+cdef double eval_hot_2D_split(size_t THREAD,
+                     double E,
+                     double mu,
+                     const double *const VEC,
+                     void *const data) nogil
+
+cdef double eval_hot_2D_norm_split() nogil
+
+    

--- a/xpsi/surface_radiation_field/hot_wrapper.pyx
+++ b/xpsi/surface_radiation_field/hot_wrapper.pyx
@@ -8,10 +8,10 @@ from xpsi.surface_radiation_field.hot_BB cimport (init_hot_BB,
                                                      eval_hot_BB,
                                                      eval_hot_norm_BB)
 #4D-Numerical
-from xpsi.surface_radiation_field.hot_Num4D cimport (init_hot_Num4D,
-                                                     free_hot_Num4D,
-                                                     eval_hot_Num4D,
-                                                     eval_hot_norm_Num4D)
+# from xpsi.surface_radiation_field.hot_Num4D cimport (init_hot_Num4D,
+#                                                      free_hot_Num4D,
+#                                                      eval_hot_Num4D,
+#                                                      eval_hot_norm_Num4D)
 
 #Blackbody-burst (with beaming and polarization)
 from xpsi.surface_radiation_field.hot_BB_burst cimport (init_hot_BB_burst,
@@ -37,7 +37,16 @@ from xpsi.surface_radiation_field.hot_user cimport (init_hot_user,
 from xpsi.surface_radiation_field.hot_Num5D_split cimport (init_hot_Num5D,
                                                eval_hot_Num5D_I,
                                                eval_hot_norm_Num5D,
-                                               free_hot_Num5D)
+                                               free_hot_Num5D,
+                                               produce_2D_data_Num5D,
+                                               make_atmosphere_2D_Num5D)
+
+from xpsi.surface_radiation_field.hot_Num4D_split cimport (init_hot_Num4D,
+                                               eval_hot_Num4D,
+                                               eval_hot_norm_Num4D,
+                                               free_hot_Num4D,
+                                               produce_2D_data_Num4D,
+                                               make_atmosphere_2D_Num4D)
 
 
 #----------------------------------------------------------------------->>>
@@ -222,3 +231,20 @@ cdef double eval_hot_norm() nogil:
         printf("WARNING: Wrong atmosphere extension provided for hot region(s)."
                "Defaulting to Blackbody (atm_ext=BB).\n")
         return eval_hot_norm_BB()
+
+
+cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const data) nogil:
+    if atmos_extension == 6:
+        return produce_2D_data_Num5D(THREAD,VEC,data)
+    elif atmos_extension == 2:
+        return produce_2D_data_Num4D(THREAD,VEC,data)
+    else:
+        printf("Error: atmosphere extension must either be 6 or 2 when using split atmospheres")
+
+cdef object make_atmosphere_2D(double *I_data, void *const data):
+    if atmos_extension == 6:
+        return make_atmosphere_2D_Num5D(I_data,data)
+    elif atmos_extension == 2:
+        return make_atmosphere_2D_Num4D(I_data,data)
+    else:
+        printf("Error: atmosphere extension must either be 6 or 2 when using split atmospheres")

--- a/xpsi/surface_radiation_field/hot_wrapper.pyx
+++ b/xpsi/surface_radiation_field/hot_wrapper.pyx
@@ -241,10 +241,10 @@ cdef double* produce_2D_data(size_t THREAD, const double *const VEC, void *const
     else:
         printf("Error: atmosphere extension must either be 6 or 2 when using split atmospheres")
 
-cdef object make_atmosphere_2D(double *I_data, void *const data):
+cdef object make_atmosphere_2D(double *I_data, const double *const VEC, void *const data):
     if atmos_extension == 6:
         return make_atmosphere_2D_Num5D(I_data,data)
     elif atmos_extension == 2:
-        return make_atmosphere_2D_Num4D(I_data,data)
+        return make_atmosphere_2D_Num4D(I_data,VEC,data)
     else:
         printf("Error: atmosphere extension must either be 6 or 2 when using split atmospheres")


### PR DESCRIPTION
I hope doing this in a pull request makes sense, I thought of writing a status update in the issue itself but there you cannot easily see my code updates as neatly.

### What is the goal?
The goal is to implement the split interpolation methodology for 4D (NSX) atmospheres, similar to how it is already implemented for 5D atmospheres. 

### What is the status?
The implementation is now finished, but there appears to be a small offset between the interpolation methods in split vs combined 4D that I don't see in split vs combined 5D.  The small offset is -68144 vs -68147 in ln-space when I run `TestRun_Num_test.py` using split vs combined methods respectively. The difference in pulse profile is not visible by eye. Selecting one energy-phase bin the difference in intensity is 0.007%. Small, but I'm still suspicious because I don't see any difference in 5D. Regardless of the small difference in the result, it runs faster. in the same testrun, I see that the `photosphere.integrate()` is almost twice as fast. The potential gain in likelihood speedup is not as impressive as there are other parts in the code that contribute heavily too, such as the ray construction(?).

I have also moved all unit conversions to `hot_wrapper.pyx`, taking place around the relevant `eval_hot_I` functions. My idea here is that I think it is cleaner if all interpolations are cleared of unit conversions, which makes the interpolators unit agnostic and easily testable with a generic case.

### Possible reasons for difference in pulse
I am a bit at a loss about what is causing the difference, but here is one idea.
- Changing the inpolation from one step to two exposes the process to different rounding errors (or otherwise numerical artefacts). I wonder if perhaps due to unit conversion (there is a unit conversion in the NSX atmosphere that involves a log) could enhance such numerical artefacts and introduce a slight error.

### How could that difference be addressed
I would test if the split interpolator is healthy by comparing results from the combined interplator preferably in the test run that I have used so far. A broader parameter sweep could later identify if it is somehow parameter dependent.

### To dos related to clean-up
- I think `hot_num_4D.pyx` can already be safely removed, to be superseded by `hot_num_4D_split.pyx`. Maybe the name can be shortened.
-  Same for `hot_num_2D.pyx`, but in this case some edits are left in the `hot_wrapper.pyx`
- Commented lines that serve no function can be removed.
- Docstrings.
