### PR TITLE
Avoid taking log of 0 when channel 0 is included.

### DIFF
--- a/xpsi/PostProcessing/_pulse.py
+++ b/xpsi/PostProcessing/_pulse.py
@@ -449,7 +449,7 @@ class PulsePlot(SignalPlot):
                                        rasterized = self._rasterized)
 
         incident.set_edgecolor('face')
-        self._ax.set_ylim([ref.energy_edges[0],
+        self._ax.set_ylim([_np.max([ref.energy_edges[0],0.001]),
                            ref.energy_edges[-1]])
         self._ax.set_yscale('log')
 
@@ -529,7 +529,7 @@ class PulsePlot(SignalPlot):
                                       rasterized = self._rasterized)
 
         registered.set_edgecolor('face')
-        self._ax_registered.set_ylim([ref.data.channels[0],
+        self._ax_registered.set_ylim([_np.max([ref.data.channels[0],0.001]),
                                       ref.data.channels[-1]])
         self._ax_registered.set_yscale('log')
 

--- a/xpsi/PostProcessing/_residual.py
+++ b/xpsi/PostProcessing/_residual.py
@@ -179,7 +179,7 @@ class ResidualPlot(SignalPlot):
                                         rasterized = self._rasterized)
         data.set_edgecolor('face')
 
-        self._ax_data.set_ylim([channel_edges[0],
+        self._ax_data.set_ylim([_np.max([channel_edges[0],0.001]),
                                 channel_edges[-1]])
         self._ax_data.set_yscale(self.yscale)
 
@@ -227,7 +227,7 @@ class ResidualPlot(SignalPlot):
                                           rasterized = self._rasterized)
         model.set_edgecolor('face')
 
-        self._ax_model.set_ylim([channel_edges[0],
+        self._ax_model.set_ylim([_np.max([channel_edges[0],0.001]),
                                  channel_edges[-1]])
         self._ax_model.set_yscale(self.yscale)
 
@@ -278,7 +278,7 @@ class ResidualPlot(SignalPlot):
 
         self._ax_resid.axvline(1.0, lw=self._tick_width, color='k')
 
-        self._ax_resid.set_ylim([channel_edges[0],
+        self._ax_resid.set_ylim([_np.max([channel_edges[0],0.001]),
                                  channel_edges[-1]])
         self._ax_resid.set_yscale(self.yscale)
 

--- a/xpsi/PostProcessing/_spectrum.py
+++ b/xpsi/PostProcessing/_spectrum.py
@@ -687,7 +687,7 @@ class SpectrumPlot(SignalPlot):
 
         ax.set_ylim(bottom = view_y_bottom)
 
-        ax.set_xlim([self._signal.energy_edges[0],
+        ax.set_xlim([_np.max([self._signal.energy_edges[0],0.001]),
                      self._signal.energy_edges[-1]])
         locmaj = LogLocator(base=10.0, numticks=100)
         ax.yaxis.set_major_locator(locmaj)
@@ -760,7 +760,7 @@ class SpectrumPlot(SignalPlot):
                                           **self._background_line_kwargs)
 
         ax = self._ax_registered_1d
-        ax.set_xlim([ref.data.channels[0],
+        ax.set_xlim([_np.max([ref.data.channels[0],0.001]),
                      ref.data.channels[-1]])
         locmaj = LogLocator(base=10.0, numticks=100)
         ax.yaxis.set_major_locator(locmaj)
@@ -794,7 +794,7 @@ class SpectrumPlot(SignalPlot):
                                     rasterized = self._rasterized)
 
         registered.set_edgecolor('face')
-        self._ax_registered.set_xlim([ref.data.channels[0],
+        self._ax_registered.set_xlim([_np.max([ref.data.channels[0],0.001]),
                                       ref.data.channels[-1]])
 
         self._registered_cb = plt.colorbar(registered,


### PR DESCRIPTION
The lower limit for the channels in signal plots was set to 0.001 instead of 0, to avoid only showing the channel 0 when it is included and logarithmic scale is used. 

However, I see now that the original behaviour of the code was not in principle wrong. Using a logarithmic scale is just a bad choice if including channel 0 (it makes zeroth bin infinitely large). Do you think this change is still worth doing? 

Attached is an example of the pulse plot including channel 0, using the old code  (only the counts from channel 0 are visible the middle bottom panel).
![pulse_old](https://github.com/user-attachments/assets/1e233566-5fe4-4a0e-985e-9093efaaff3f)
and here using the new code:
![pulse_new](https://github.com/user-attachments/assets/ba3e1d39-b710-42d4-addc-bbbe86d06458)
 