### PR TITLE
Remove py2 documentation from build docs action

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -25,38 +25,6 @@ jobs:
     - name: install gsl
       run: |
         sudo apt-get install -y libgsl-dev
-    - name: check out X-PSI v1.2.1
-      uses: actions/checkout@v3
-      with:
-        ref: python2
-    - name: Install Python2 Conda environment with Micromamba
-      uses: mamba-org/setup-micromamba@v1
-      with:
-        cache-env: true
-        cache-env-key: env-envkey-${{ github.sha }}-${{ github.run_attempt }}
-        environment-file: basic_environment.yml
-        environment-name: xpsipy2
-        extra-specs: |
-          python=2.7
-    - name : install docs dependencies
-      run: |
-        micromamba install sphinx=1.8.5 decorator=4.4.1 h5py
-        micromamba install -c conda-forge nbsphinx=0.5.1 nbconvert=5.6.1
-        pip install sphinxcontrib-websupport==1.1.2 sphinx_rtd_theme==0.4.3
-    - name: install X-PSI package
-      run: |
-       python setup.py install
-      shell: bash -l {0}
-      env:
-        CC:   gcc-10
-    - name : build docs
-      run: make html
-      working-directory: docs/
-    - name : move docs
-      run : |
-        mkdir ../../../../py2
-        mv build/html/* ../../../../py2/
-      working-directory: docs/
 
     - name: check out X-PSI main
       uses: actions/checkout@v3
@@ -88,8 +56,6 @@ jobs:
     - name : build docs
       run: | 
         make html
-        mkdir build/html/py2
-        mv ../../../../py2/* build/html/py2/
       working-directory: docs/
 
     - name: Deploy to GitHub Pages

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ more detail, including links to appropriate papers and BibTeX entries.
 
 Copyright and Licensing
 -----------------------
-All content © 2016-2023 the authors. 
+All content © 2016-2025 the authors. 
 The code is distributed under the GNU General Public License v3.0; see `LICENSE <LICENSE>`_ for details.
 
 Legacy

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -5,14 +5,7 @@ X-ray Pulse Simulation and Inference (X-PSI)
 ********************************************
 
 **An open-source package for neutron star**
-**\ X-ray Pulse Simulation and Inference.**
-
-.. warning::
-    You are looking at the **Python3** version of the documentation.  
-    **The Python2 version of X-PSI (v1.2.1 and below) is now deprecated**, 
-    please migrate your code to Python3 and X-PSI v2.0 or higher.
-    The Python2 documentation for X-PSI is still available at 
-    `this link <https://xpsi-group.github.io/xpsi/py2/index.html>`_. 
+**\ X-ray Pulse Simulation and Inference.** 
 
 X-PSI is designed to simulate rotationally-modified (pulsed) surface X-ray
 emission from neutron stars, taking into account relativistic effects on


### PR DESCRIPTION
Removed what I think are all of the now irrelevant commands from the build_docs action, have also cross-checked with the neost build_docs action.

One question - should we upgrade micromambav1 to v2? But not sure what this would do.