### PR TITLE
Precisions for parameters in corner plots

### DIFF
--- a/xpsi/PostProcessing/_corner.py
+++ b/xpsi/PostProcessing/_corner.py
@@ -37,7 +37,6 @@ class CornerPlotter(PostProcessor):
 
     """
 
-
     @fix_random_seed
     @make_verbose('Executing posterior density estimation',
                   'Posterior density estimation complete')
@@ -633,6 +632,7 @@ class CornerPlotter(PostProcessor):
                     if xmax - tick[-1].get_loc() < gap_wanted:
                         tick[-1].label1.set_visible(False)
 
+        self.precisions_dict = self.subset_to_plot[0].precisions
         if prior_density:
             # only report KL divergence for topmost posterior,
             # but plot the priors if available for the other posteriors
@@ -676,7 +676,7 @@ class CornerPlotter(PostProcessor):
 
 
         self.credible_intervals=OrderedDict()
-
+      
         if "precisions" in kwargs:
             precisions = kwargs.get('precisions')
             if (not isinstance(precisions, list)) or (not all((isinstance(element, int) or element==None) for element in precisions)):
@@ -687,9 +687,16 @@ class CornerPlotter(PostProcessor):
                 print("Warning: Precisions list has wrong number of dimensions. " +
                 "Using the automatic default precisions instead.")
                 precisions = [None]*plotter.subplots.shape[0]
+        
+        elif self.precisions_dict is not None:
+            precisions=[]
+            for name in self.params.names:
+                precisions.append(self.precisions_dict[name])
+        
         else:
             precisions = [None]*plotter.subplots.shape[0]
-
+        
+        
         if "ci_gap" in kwargs:
             self.ci_gap = kwargs.get("ci_gap")
         else:
@@ -746,7 +753,6 @@ class CornerPlotter(PostProcessor):
 
         """
         run = posterior.subset_to_plot[0]
-
 
         #self.samples[posterior.ID]=samples
 

--- a/xpsi/PostProcessing/_metadata.py
+++ b/xpsi/PostProcessing/_metadata.py
@@ -34,7 +34,7 @@ class Metadata(object):
     """
 
     def __init__(self, ID, names, bounds=None, labels=None,
-                 implementation=None, kde_settings=None, truths=None):
+                 implementation=None, kde_settings=None, truths=None, precisions=None):
 
         self.ID = ID
         self.names = names
@@ -59,6 +59,11 @@ class Metadata(object):
             self.truths = truths
         else:
             self._truths = dict(list(zip(self.names, [None] * len(self.names))))
+        
+        if precisions is not None:
+            self.precisions = precisions
+        else:
+            self._precisions = None
 
     @property
     def ID(self):
@@ -225,4 +230,26 @@ class Metadata(object):
         for i, name in enumerate(self.names):
             v[i] = self.truths[name]
         return v
+    
+    @property
+    def precisions(self):
+        """ Get the parameter precisions. """
+
+        return self._precisions
+
+    @precisions.setter
+    def precisions(self, obj):
+        """ Set the parameter precisions, which should be a dictionary containing integers or Nones. """
+
+        try:
+            if len(obj) != len(self.names):
+                raise TypeError
+            for key in obj:
+                if not isinstance(obj[key], (int | None)):
+                    raise TypeError
+        except TypeError:
+            print('Invalid parameter name specification. See the docstring.')
+            raise
+
+        self._precisions =  obj
 

--- a/xpsi/PostProcessing/_runs.py
+++ b/xpsi/PostProcessing/_runs.py
@@ -132,7 +132,7 @@ class Runs(Metadata):
                                       transform=_transform,
                                       overwrite_transformed=_overwrite,
                                       **kwargs))
-
+        
         return cls(runs, likelihood, ID, **kwargs)
 
     def set_subset(self, IDs=None, combine=False, combine_all=False,
@@ -210,7 +210,8 @@ class Runs(Metadata):
                   'names': self.names,
                   'bounds': self.bounds,
                   'labels': self.labels,
-                  'truths': self.truths}
+                  'truths': self.truths,
+                  'precisions': self.precisions}
 
         self._combined = NestedBackend(file_root,
                                        base_dir = base_dir,


### PR DESCRIPTION
Following Basdorsman's suggestion in issue #393, we develop here a new structure that allows to choose each precision for the parameters loaded from the runs and showed in the corner plots. We extended the Runs tool so it can assign chosen precisions for the parameters, using a distribution of integers and/or None objects, which, in the latter case makes the corner plots to choose the original default precision for the involved parameters.