### PR TITLE
default arg changed to `None`

### DIFF
--- a/examples/examples_module_generator/_auto_modules/main.py
+++ b/examples/examples_module_generator/_auto_modules/main.py
@@ -751,7 +751,7 @@ parser.add_argument('--hot-atmosphere-size',
 
 parser.add_argument('--image-order-limit',
                          type=int,
-                         default=3,
+                         default=None,
                          help='The highest-order image to sum over. Either a positive integer, or do not pass an argument if a hard limit is not desired.',
                          comment_line_above='global resolution flags')
 

--- a/xpsi/module_generator.py
+++ b/xpsi/module_generator.py
@@ -1278,7 +1278,7 @@ module += (
 '''
 parser.add_argument('--image-order-limit',
                          type=int,
-                         default=3,
+                         default=None,
                          help='The highest-order image to sum over. Either a positive integer, or do not pass an argument if a hard limit is not desired.',
                          comment_line_above='global resolution flags')
 '''


### PR DESCRIPTION
default arg changed to `None` in accordance with the deafult arg for `image_order_limit` in `HotRegion`