### PR TITLE
254 unit tests for hotregion

### DIFF
--- a/docs/source/Hot_region_complexity.ipynb
+++ b/docs/source/Hot_region_complexity.ipynb
@@ -194,7 +194,7 @@
     "                              num_leaves=100,\n",
     "                              num_rays=200,\n",
     "                              do_fast=False,\n",
-    "                              is_secondary=True,\n",
+    "                              is_antiphased=True,\n",
     "                              prefix='s')\n",
     "\n",
     "from xpsi import HotRegions\n",
@@ -676,9 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -762,9 +760,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -939,9 +935,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1017,9 +1011,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1086,9 +1078,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1197,7 +1187,7 @@
     "                              num_leaves=100,\n",
     "                              num_rays=200,\n",
     "                              do_fast=False,\n",
-    "                              is_secondary=True,\n",
+    "                              is_antiphased=True,\n",
     "                              prefix='s')\n",
     "\n",
     "from xpsi import HotRegions\n",
@@ -1685,9 +1675,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/docs/source/Surface_radiation_field_tools.ipynb
+++ b/docs/source/Surface_radiation_field_tools.ipynb
@@ -835,7 +835,7 @@
     "                              num_leaves=100,\n",
     "                              num_rays=200,\n",
     "                              do_fast=False,\n",
-    "                              is_secondary=True,\n",
+    "                              is_antiphased=True,\n",
     "                              atm_ext=\"BB\",#default blackbody, other options: \"Num4D\" or \"user\"               \n",
     "                              prefix='s')\n",
     "\n",
@@ -1075,7 +1075,7 @@
     "                              num_leaves=100,\n",
     "                              num_rays=200,\n",
     "                              do_fast=False,\n",
-    "                              is_secondary=True,\n",
+    "                              is_antiphased=True,\n",
     "                              atm_ext=\"Num4D\",#default blackbody, other options: \"Num4D\" or \"user\"               \n",
     "                              prefix='s')\n",
     "\n",
@@ -1314,9 +1314,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/docs/source/old/Multiple_imaging.ipynb
+++ b/docs/source/old/Multiple_imaging.ipynb
@@ -816,9 +816,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2221,7 +2219,7 @@
     "                            num_leaves=1024,\n",
     "                            num_phases=100,\n",
     "                            num_rays=1024,\n",
-    "                            is_secondary=False,\n",
+    "                            is_antiphased=False,\n",
     "                            prefix='p')\n",
     "\n",
     "bounds = dict(super_colatitude = (0.001, math.pi - 0.001),\n",
@@ -2839,5 +2837,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/examples_fast/Modules/main.py
+++ b/examples/examples_fast/Modules/main.py
@@ -108,7 +108,7 @@ hot_spot = xpsi.HotRegion(bounds=bounds,
                                 max_sqrt_num_cells=64,
                                 num_leaves=64,
                                 num_rays=512,
-                                is_secondary=True,
+                                is_antiphased=True,
                                 image_order_limit=3, # up to tertiary
                                 prefix='hot')
 

--- a/examples/examples_fast/Sampling.ipynb
+++ b/examples/examples_fast/Sampling.ipynb
@@ -453,7 +453,7 @@
     "                                max_sqrt_num_cells=64,\n",
     "                                num_leaves=64,\n",
     "                                num_rays=512,\n",
-    "                                is_secondary=True,\n",
+    "                                is_antiphased=True,\n",
     "                                image_order_limit=3, # up to tertiary\n",
     "                                prefix='hot')\n"
    ]
@@ -838,9 +838,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/xpsi/HotRegion.py
+++ b/xpsi/HotRegion.py
@@ -289,7 +289,10 @@ class HotRegion(ParameterSubspace):
         self.image_order_limit = image_order_limit
 
         self._split = split
-        self.symmetry = symmetry
+        if not isinstance(self._split, bool):
+            raise TypeError("The 'split' argument signifies split atmosphere interpolation and must be a boolean.")
+
+        self._symmetry = symmetry
 
         self.atm_ext = atm_ext
         self.beam_opt = beam_opt

--- a/xpsi/HotRegion.py
+++ b/xpsi/HotRegion.py
@@ -147,10 +147,6 @@ class HotRegion(ParameterSubspace):
         region (``super`` region or an ``omit`` region) then the centre
         of that region is the point that is *aligned* to a meridian.
 
-    :param bool is_secondary:
-        Deprecated. You can use or the ``is_antiphased`` keyword argument
-        instead, which has precisely the same effect.
-
     .. note::
 
         The parameters are as follows:
@@ -272,7 +268,7 @@ class HotRegion(ParameterSubspace):
                  image_order_limit = None,
                  **kwargs):
 
-        self.is_antiphased = kwargs.get('is_secondary', is_antiphased)
+        self.is_antiphased = is_antiphased
 
         self.do_fast = do_fast
 
@@ -728,22 +724,17 @@ class HotRegion(ParameterSubspace):
         return self._num_cells
 
     @property
-    def is_secondary(self):
-        """ Shift the hot region by half a rotational cycle? Deprecated. """
+    def is_antiphased(self):
+        """ Shift the hot region by half a rotational cycle? """
         return self._is_antiphased
-
-    @is_secondary.setter
-    def is_secondary(self, is_secondary):
+    
+    @is_antiphased.setter
+    def is_antiphased(self, is_antiphased):
         if not isinstance(is_antiphased, bool):
             raise TypeError('Use a boolean to specify whether or not the '
                             'hot region should be shifted by half a cycle.')
         else:
             self._is_antiphased = is_antiphased
-
-    @property
-    def is_antiphased(self):
-        """ Shift the hot region by half a rotational cycle? """
-        return self._is_antiphased
 
     @property
     def atm_ext(self):
@@ -784,14 +775,6 @@ class HotRegion(ParameterSubspace):
         else:
             raise TypeError('Got an unrecognised beam_opt argument. Note that the only allowed '
                             'beam_opt options are 0, 1, 2, 3 (see documentation).')
-
-    @is_antiphased.setter
-    def is_antiphased(self, is_antiphased):
-        if not isinstance(is_antiphased, bool):
-            raise TypeError('Use a boolean to specify whether or not the '
-                            'hot region should be shifted by half a cycle.')
-        else:
-            self._is_antiphased = is_antiphased
 
     def print_settings(self):
         """ Print numerical settings. """

--- a/xpsi/HotRegion.py
+++ b/xpsi/HotRegion.py
@@ -288,7 +288,7 @@ class HotRegion(ParameterSubspace):
         if not isinstance(self._split, bool):
             raise TypeError("The 'split' argument signifies split atmosphere interpolation and must be a boolean.")
 
-        self._symmetry = symmetry
+        self.symmetry = symmetry
 
         self.atm_ext = atm_ext
         self.beam_opt = beam_opt
@@ -517,7 +517,6 @@ class HotRegion(ParameterSubspace):
             raise TypeError('Declare symmetry existence with a boolean.')
 
         self._symmetry = declaration
-
         # find the required integrator
         if declaration: # can we safely assume azimuthal invariance?
             if self._split:

--- a/xpsi/Parameter.py
+++ b/xpsi/Parameter.py
@@ -96,7 +96,7 @@ class Derive(object, metaclass=ABCMeta):
                                       num_leaves=100,
                                       num_rays=200,
                                       do_fast=False,
-                                      is_secondary=True,
+                                      is_antiphased=True,
                                       prefix='s')
 
         from xpsi import HotRegions

--- a/xpsi/tests/test_hotregion.py
+++ b/xpsi/tests/test_hotregion.py
@@ -23,7 +23,6 @@ class TestHotRegion(object):
                           'super_colatitude': np.pi/4,
                           'super_temperature': 6.}
 
-        cls.HotRegion = HotRegion(cls.hot_bounds, cls.hot_values)
         cls.space_values = {'frequency': 401., #Hz
                             'distance': 5., #kpc
                             'mass': 2., #Msun
@@ -37,10 +36,9 @@ class TestHotRegion(object):
                             'cos_inclination': (None, None)
                             }
         
-        cls.Spacetime = Spacetime(bounds=cls.space_bounds, values=cls.space_values)
-        cls.mock_photosphere = {'mode_frequency': cls.space_values['frequency']}
-        cls.Photosphere = Photosphere(hot=cls.HotRegion, bounds={'mode_frequency': (None, None)}, 
-                                      values={'mode_frequency': cls.space_values['frequency']})
+        # cls.Spacetime = Spacetime(bounds=cls.space_bounds, values=cls.space_values)
+        # cls.mock_photosphere = {'mode_frequency': cls.space_values['frequency']}
+        # cls.Photosphere = Photosphere(hot=cls.HotRegion, bounds={'mode_frequency': (None, None)}, values={'mode_frequency': cls.space_values['frequency']})
     
     def test_hotregion_class_initializes(self):
         HotRegion(self.hot_bounds, self.hot_values)
@@ -72,16 +70,17 @@ class TestHotRegion(object):
             HotRegion(bounds, self.hot_values)
             
     def test_hotregion_produces_default_parameters(self):
-        self.HotRegion.get_param('phase_shift')
-        self.HotRegion.get_param('super_colatitude')
-        self.HotRegion.get_param('super_radius')
-        self.HotRegion.get_param('super_temperature')
-        self.HotRegion.get_param('cede_colatitude')
-        self.HotRegion.get_param('cede_radius')
-        self.HotRegion.get_param('cede_azimuth')
-        self.HotRegion.get_param('omit_colatitude')
-        self.HotRegion.get_param('omit_radius')
-        self.HotRegion.get_param('omit_azimuth')
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_hotregion.get_param('phase_shift')
+        test_hotregion.get_param('super_colatitude')
+        test_hotregion.get_param('super_radius')
+        test_hotregion.get_param('super_temperature')
+        test_hotregion.get_param('cede_colatitude')
+        test_hotregion.get_param('cede_radius')
+        test_hotregion.get_param('cede_azimuth')
+        test_hotregion.get_param('omit_colatitude')
+        test_hotregion.get_param('omit_radius')
+        test_hotregion.get_param('omit_azimuth')
         
         
     def test_hotregion_handles_cede(self):
@@ -110,45 +109,49 @@ class TestHotRegion(object):
     @pytest.mark.parametrize("num_rays", [50, 50.5, "invalid"])
     def test_set_num_rays(self, num_rays):
         # Test that integer, float and invalid values for num_rays have corect set and get. Raise error if invalid.
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
         
         fast_num_rays = 50
         if isinstance(num_rays, float | int):
-            self.HotRegion.set_num_rays(num_rays, fast_num_rays)
-            assert self.HotRegion.num_rays == int(num_rays), f"Expected num_rays to be {num_rays}, got {self.HotRegion.num_rays}"
-            assert self.HotRegion._fast_num_rays == fast_num_rays, f"Expected _fast_num_rays to be {fast_num_rays}, got {self.HotRegion._fast_num_rays}"    
+            test_hotregion.set_num_rays(num_rays, fast_num_rays)
+            assert test_hotregion.num_rays == int(num_rays), f"Expected num_rays to be {num_rays}, got {test_hotregion.num_rays}"
+            assert test_hotregion._fast_num_rays == fast_num_rays, f"Expected _fast_num_rays to be {fast_num_rays}, got {test_hotregion._fast_num_rays}"    
         else:
             with pytest.raises(ValueError):
-                self.HotRegion.set_num_rays(num_rays, fast_num_rays)
+                test_hotregion.set_num_rays(num_rays, fast_num_rays)
                 
     def test_image_order_limit_getter(self):
         # Set a value directly to the private attribute
-        self.HotRegion._image_order_limit = 5
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_hotregion._image_order_limit = 5
     
         # Validate the getter returns the correct value
-        assert self.HotRegion.image_order_limit == 5, (
-            f"Expected image_order_limit to be 5, but got {self.HotRegion.image_order_limit}"
+        assert test_hotregion.image_order_limit == 5, (
+            f"Expected image_order_limit to be 5, but got {test_hotregion.image_order_limit}"
         )
 
     @pytest.mark.parametrize("image_order_limit", [10, None, "invalid", 3.5])
     def test_image_order_limit_setter_valid(self, image_order_limit):
         # Test with a positive integer
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        
         if image_order_limit == 10:
-            self.HotRegion.image_order_limit = 10
-            assert self.HotRegion._image_order_limit == 10, (
-                f"Expected _image_order_limit to be 10, but got {self.HotRegion._image_order_limit}"
+            test_hotregion.image_order_limit = 10
+            assert test_hotregion._image_order_limit == 10, (
+                f"Expected _image_order_limit to be 10, but got {test_hotregion._image_order_limit}"
             )
         elif image_order_limit == None:
-            self.HotRegion.image_order_limit = None
-            assert self.HotRegion._image_order_limit is None, (
-                f"Expected _image_order_limit to be None, but got {self.HotRegion._image_order_limit}"
+            test_hotregion.image_order_limit = None
+            assert test_hotregion._image_order_limit is None, (
+                f"Expected _image_order_limit to be None, but got {test_hotregion._image_order_limit}"
             )
         elif image_order_limit == "invalid":
             # Test with a non-integer value
             with pytest.raises(TypeError, match="Image order limit must be an positive integer if not None."):
-                self.HotRegion.image_order_limit = "invalid"
+                test_hotregion.image_order_limit = "invalid"
         elif image_order_limit == 3.5:
             with pytest.raises(TypeError, match="Image order limit must be an positive integer if not None."):
-                self.HotRegion.image_order_limit = 3.5
+                test_hotregion.image_order_limit = 3.5
 
     @pytest.mark.parametrize(
         "sqrt_num_cells, min_sqrt_num_cells, max_sqrt_num_cells, fast_sqrt_num_cells, fast_min_sqrt_num_cells, fast_max_sqrt_num_cells, expect_error",
@@ -168,36 +171,39 @@ class TestHotRegion(object):
     def test_set_num_cells(self, sqrt_num_cells, min_sqrt_num_cells, max_sqrt_num_cells,
                            fast_sqrt_num_cells, fast_min_sqrt_num_cells, fast_max_sqrt_num_cells,
                            expect_error):
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        
         if expect_error:
             with pytest.raises(expect_error):
-                self.HotRegion.set_num_cells(
+                test_hotregion.set_num_cells(
                     sqrt_num_cells, min_sqrt_num_cells, max_sqrt_num_cells,
                     fast_sqrt_num_cells, fast_min_sqrt_num_cells, fast_max_sqrt_num_cells
                 )
         else:
-            self.HotRegion.set_num_cells(
+            test_hotregion.set_num_cells(
                 sqrt_num_cells, min_sqrt_num_cells, max_sqrt_num_cells,
                 fast_sqrt_num_cells, fast_min_sqrt_num_cells, fast_max_sqrt_num_cells
             )
 
             # Validate attributes for regular cells
-            assert self.HotRegion.sqrt_num_cells == sqrt_num_cells
-            assert self.HotRegion._num_cells == sqrt_num_cells**2
-            assert self.HotRegion._min_sqrt_num_cells == min_sqrt_num_cells
-            assert self.HotRegion._max_sqrt_num_cells == max_sqrt_num_cells
+            assert test_hotregion.sqrt_num_cells == sqrt_num_cells
+            assert test_hotregion._num_cells == sqrt_num_cells**2
+            assert test_hotregion._min_sqrt_num_cells == min_sqrt_num_cells
+            assert test_hotregion._max_sqrt_num_cells == max_sqrt_num_cells
 
             # Validate attributes for fast cells
-            assert self.HotRegion._fast_num_cells == fast_sqrt_num_cells**2
-            assert self.HotRegion._fast_min_sqrt_num_cells == fast_min_sqrt_num_cells
-            assert self.HotRegion._fast_max_sqrt_num_cells == fast_max_sqrt_num_cells
+            assert test_hotregion._fast_num_cells == fast_sqrt_num_cells**2
+            assert test_hotregion._fast_min_sqrt_num_cells == fast_min_sqrt_num_cells
+            assert test_hotregion._fast_max_sqrt_num_cells == fast_max_sqrt_num_cells
 
     def test_leaves_property(self):
         # Set a value directly to the private attribute
-        self.HotRegion._leaves = "test_value"
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_hotregion._leaves = "test_value"
 
         # Verify that the property returns the correct value
-        assert self.HotRegion.leaves == "test_value", (
-            f"Expected leaves to return 'test_value', but got {self.HotRegion.leaves}"
+        assert test_hotregion.leaves == "test_value", (
+            f"Expected leaves to return 'test_value', but got {test_hotregion.leaves}"
         )
         
     @pytest.mark.parametrize(
@@ -235,14 +241,15 @@ class TestHotRegion(object):
         ]
     )
     def test_set_phases(self,num_leaves, num_phases, phases, fast_num_leaves, fast_num_phases, fast_phases, do_fast, expect_error):    
-        HotRegion.do_fast = do_fast
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_hotregion.do_fast = do_fast
         # Expect error for invalid cases
         if expect_error:
             with pytest.raises(expect_error):
-                self.HotRegion.set_phases(num_leaves, num_phases=num_phases, phases=phases, fast_num_leaves=fast_num_leaves, fast_num_phases=fast_num_phases, fast_phases=fast_phases)
+                test_hotregion.set_phases(num_leaves, num_phases=num_phases, phases=phases, fast_num_leaves=fast_num_leaves, fast_num_phases=fast_num_phases, fast_phases=fast_phases)
         else:
             # Test valid cases
-            self.HotRegion.set_phases(num_leaves, num_phases=num_phases, phases=phases, fast_num_leaves=fast_num_leaves, fast_num_phases=fast_num_phases, fast_phases=fast_phases)
+            test_hotregion.set_phases(num_leaves, num_phases=num_phases, phases=phases, fast_num_leaves=fast_num_leaves, fast_num_phases=fast_num_phases, fast_phases=fast_phases)
             if phases is None and num_phases is None:
                 num_temp = num_leaves
                 linspace_temp = np.linspace(0, 1, num_temp)
@@ -252,32 +259,34 @@ class TestHotRegion(object):
             else:
                 linspace_temp = phases
             
-            assert np.allclose(self.HotRegion._phases_cycles, linspace_temp), f"Expected phases {linspace_temp}, but got {self.HotRegion._phases_cycles}"
-            assert np.allclose(self.HotRegion._leaves, np.linspace(0.0, 2*np.pi, 5)), f"Expected leaves to be np.linspace(0.0, 2*np.pi, 5), but got {self.HotRegion._leaves}"
+            assert np.allclose(test_hotregion._phases_cycles, linspace_temp), f"Expected phases {linspace_temp}, but got {test_hotregion._phases_cycles}"
+            assert np.allclose(test_hotregion._leaves, np.linspace(0.0, 2*np.pi, 5)), f"Expected leaves to be np.linspace(0.0, 2*np.pi, 5), but got {test_hotregion._leaves}"
             
         #HotRegion.do_fast = False # restore
         
         
     def test_phases_in_cycles_property(self):
         # Set a value directly to the private attribute
-        self.HotRegion._phases_cycles = "test_value"
-        self.HotRegion._fast_phases_cycles = "test_value"
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_hotregion._phases_cycles = "test_value"
+        test_hotregion._fast_phases_cycles = "test_value"
 
         # Verify that the property returns the correct value
-        assert self.HotRegion.phases_in_cycles == "test_value", (
-            f"Expected phases_in_cycles to return 'test_value', but got {self.HotRegion.phases_in_cycles}"
+        assert test_hotregion.phases_in_cycles == "test_value", (
+            f"Expected phases_in_cycles to return 'test_value', but got {test_hotregion.phases_in_cycles}"
         )
-        assert self.HotRegion.fast_phases_in_cycles == "test_value", (
-            f"Expected fast_phases_in_cycles to return 'test_value', but got {self.HotRegion.fast_phases_in_cycles}"
+        assert test_hotregion.fast_phases_in_cycles == "test_value", (
+            f"Expected fast_phases_in_cycles to return 'test_value', but got {test_hotregion.fast_phases_in_cycles}"
         )
         
     def test_num_cells_property(self):
         # Set a value directly to the private attribute
-        self.HotRegion._num_cells = "test_value"
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_hotregion._num_cells = "test_value"
 
         # Verify that the property returns the correct value
-        assert self.HotRegion.num_cells == "test_value", (
-            f"Expected num_cells to return 'test_value', but got {self.HotRegion.num_cells}"
+        assert test_hotregion.num_cells == "test_value", (
+            f"Expected num_cells to return 'test_value', but got {test_hotregion.num_cells}"
         )
         
         
@@ -295,17 +304,18 @@ class TestHotRegion(object):
         ]
     )
     def test_is_antiphased(self, input_value, expected_value, expect_error):
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
     
         # Handle invalid cases
         if expect_error:
             with pytest.raises(expect_error):
-                self.HotRegion.is_antiphased = input_value
+                test_hotregion.is_antiphased = input_value
         else:
             # Set the value
-            self.HotRegion.is_antiphased = input_value
+            test_hotregion.is_antiphased = input_value
             
             # Assert getter returns the correct value
-            assert self.HotRegion.is_antiphased == expected_value, f"Expected {expected_value}, but got {self.HotRegion.is_antiphased}"
+            assert test_hotregion.is_antiphased == expected_value, f"Expected {expected_value}, but got {test_hotregion.is_antiphased}"
 
     @pytest.mark.parametrize(
         "input_extension, expected_value, expect_error",
@@ -326,15 +336,16 @@ class TestHotRegion(object):
     )
     def test_atm_ext(self, input_extension, expected_value, expect_error):
         # For invalid cases, assert that the proper exception is raised
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
         if expect_error:
             with pytest.raises(expect_error):
-                self.HotRegion.atm_ext = input_extension
+                test_hotregion.atm_ext = input_extension
         else:
             # Set the value
-            self.HotRegion.atm_ext = input_extension
+            test_hotregion.atm_ext = input_extension
             
             # Assert the getter returns the correct value
-            assert self.HotRegion.atm_ext == expected_value, f"Expected {expected_value}, but got {self.HotRegion.atm_ext}"
+            assert test_hotregion.atm_ext == expected_value, f"Expected {expected_value}, but got {test_hotregion.atm_ext}"
     
     
     @pytest.mark.parametrize(
@@ -355,19 +366,21 @@ class TestHotRegion(object):
     )
     def test_beam_opt(self, input_option, expected_value, expect_error):
         # For invalid cases, assert that the proper exception is raised
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
         if expect_error:
             with pytest.raises(expect_error):
-                self.HotRegion.beam_opt = input_option
+                test_hotregion.beam_opt = input_option
         else:
             # Set the value
-            self.HotRegion.beam_opt = input_option
+            test_hotregion.beam_opt = input_option
             
             # Assert the getter returns the correct value
-            assert self.HotRegion.beam_opt == expected_value, f"Expected {expected_value}, but got {self.HotRegion.beam_opt}"
+            assert test_hotregion.beam_opt == expected_value, f"Expected {expected_value}, but got {test_hotregion.beam_opt}"
 
     def test_print_settings(self, capfd):
         # Call the method
-        self.HotRegion.print_settings()
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_hotregion.print_settings()
         
         # Capture the output
         captured = capfd.readouterr()
@@ -378,11 +391,16 @@ class TestHotRegion(object):
     def test_construct_cellmesh_runs(self):
         # This function calls multiple underlying functions, so it is more of an integration test.
         # Example valid case, not asserting the actual outcome yet.
-        self.HotRegion.fast_mode = False
-        self.HotRegion.set_num_cells(32, 10, 80, 16, 4, 16)
-        self.HotRegion._HotRegion__construct_cellMesh(self.Spacetime, None, 1)
+
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_spacetime = Spacetime(bounds=self.space_bounds, values=self.space_values)
+
+        test_hotregion.fast_mode = False
+        test_hotregion.set_num_cells(32, 10, 80, 16, 4, 16)
+        test_hotregion._HotRegion__construct_cellMesh(test_spacetime, None, 1)
         # Not yet testing invalid cases and failing cases yet. Also: not testing yet underlying functions individually.
         
+
     @pytest.mark.parametrize(
         "super_cell_area, cede_cell_area, expected",
         [
@@ -392,16 +410,17 @@ class TestHotRegion(object):
     )
     def test_cell_area(self, super_cell_area, cede_cell_area, expected):        
         # Mock the _super_cellArea attribute
-        self.HotRegion._super_cellArea = super_cell_area
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_hotregion._super_cellArea = super_cell_area
     
         # Conditionally set or remove _cede_cellArea
         if cede_cell_area is not None:
-            self.HotRegion._cede_cellArea = cede_cell_area
-        elif hasattr(self.HotRegion, '_cede_cellArea'):
-            del self.HotRegion._cede_cellArea
+            test_hotregion._cede_cellArea = cede_cell_area
+        elif hasattr(test_hotregion, '_cede_cellArea'):
+            del test_hotregion._cede_cellArea
     
         # Access the private property using name mangling
-        cell_area = self.HotRegion._HotRegion__cellArea
+        cell_area = test_hotregion._HotRegion__cellArea
     
         # Assert the expected value
         assert cell_area == expected
@@ -409,40 +428,50 @@ class TestHotRegion(object):
     def test_compute_rays_runs(self):
         # just testing here that the __compute_rays function runs. Calibrate
         # lags is called within this function at the end.
-        self.HotRegion._HotRegion__compute_rays(self.Spacetime, 
-                                                self.Photosphere, 1)
-        #print('superlag', self.HotRegion._super_lag)
-        #print('superlag', self.HotRegion._super_lag.shape)
-        
-        
-    @pytest.mark.parametrize('cede', [True, False])
-    def test_calibrate_lag_runs(self, cede):
-        # just testing here that the __calibrate_lag function runs. Not relying
-        # on compute_rays to do that, since that function relies on this 
-        # function.
 
-        mock_r_s_over_r = 0.5924*np.ones(42)
-        self.HotRegion._r_s_over_r = mock_r_s_over_r
-        mock_super_lag = 0.1*np.ones((42, 50))
-        self.HotRegion._super_lag = mock_super_lag
-        if cede:
-            self.HotRegion._cede_r_s_over_r = mock_r_s_over_r
-            self.HotRegion._cede_lag = mock_super_lag
-        elif not cede:
-            pass
-        self.HotRegion._HotRegion__calibrate_lag(self.Spacetime, 
-                                                 self.Photosphere)
+        test_hotregion = HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_spacetime = Spacetime(bounds=self.space_bounds, values=self.space_values)
+        test_photosphere = Photosphere(hot=test_hotregion, bounds={'mode_frequency': (None, None)}, values={'mode_frequency': self.space_values['frequency']})
+    
+        test_hotregion.fast_mode = False
+        test_hotregion.set_num_cells(32, 10, 80, 16, 4, 16)
+        test_hotregion._HotRegion__construct_cellMesh(test_spacetime, None, 1)
         
+        test_hotregion._HotRegion__compute_rays(test_spacetime, 
+                                                test_photosphere, 1)
+
+    def test_calibrate_lag_runs(self):
+        # just testing here that the __calibrate_lag function runs. Relying here on 
+        # compute rays and also not testing the options for ceding vs not ceding   
+        
+        test_hotregion = HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_spacetime = Spacetime(bounds=self.space_bounds, values=self.space_values)
+        test_photosphere = Photosphere(hot=test_hotregion, bounds={'mode_frequency': (None, None)}, values={'mode_frequency': self.space_values['frequency']})
+    
+        
+        test_hotregion.fast_mode = False
+        test_hotregion.set_num_cells(32, 10, 80, 16, 4, 16)
+        test_hotregion._HotRegion__construct_cellMesh(test_spacetime, None, 1)
+        test_hotregion._HotRegion__compute_rays(test_spacetime, 
+                                                test_photosphere, 1)
+        test_hotregion._HotRegion__calibrate_lag(test_spacetime, 
+                                                 test_photosphere)
         
     def test_cellParamVecs_runs(self):
         # just testing if compute_cellParamVecs runs. I am relying on construct
         # cellmesh and compute rays, but I tested those separately above.
-        self.HotRegion._HotRegion__construct_cellMesh(self.Spacetime,
+        
+        test_hotregion = HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_spacetime = Spacetime(bounds=self.space_bounds, values=self.space_values)
+        test_photosphere = Photosphere(hot=test_hotregion, bounds={'mode_frequency': (None, None)}, values={'mode_frequency': self.space_values['frequency']})
+        test_hotregion.fast_mode=False
+        
+        test_hotregion._HotRegion__construct_cellMesh(test_spacetime,
                                   None,
                                   1)
-        self.HotRegion._HotRegion__compute_rays(self.Spacetime, 
-                                                self.Photosphere, 1)
-        self.HotRegion._HotRegion__compute_cellParamVecs()
+        test_hotregion._HotRegion__compute_rays(test_spacetime, 
+                                                test_photosphere, 1)
+        test_hotregion._HotRegion__compute_cellParamVecs()
 
     def test_psi(self):
         # Define test inputs (theta, phi, colatitude)
@@ -457,114 +486,124 @@ class TestHotRegion(object):
         )
     
         # Call the psi function
-        results = self.HotRegion.psi(theta, phi, colatitude)
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        results = test_hotregion.psi(theta, phi, colatitude)
     
         # Validate the results against the expected values
         np.testing.assert_allclose(results, expected_results, rtol=1e-6, atol=1e-8)
     
     def test_embed_runs(self):
         # Just testing that the embed function runs.
-        self.HotRegion.embed(self.Spacetime, self.Photosphere, None, 1)
+
+        test_hotregion = HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_spacetime = Spacetime(bounds=self.space_bounds, values=self.space_values)
+        test_photosphere = Photosphere(hot=test_hotregion, bounds={'mode_frequency': (None, None)}, values={'mode_frequency': self.space_values['frequency']})
+    
+        test_hotregion.fast_mode=False
+        test_hotregion.embed(test_spacetime, test_photosphere, None, 1)
         # Also testing the optional args that produce a correction.           
         # Mock function to be passed as *args
         def mock_correction_function(vector):
             return np.ones((len(vector), len(vector), 1))
 
-        self.HotRegion.embed(self.Spacetime, self.Photosphere, None, 1, mock_correction_function)
+        test_hotregion.embed(test_spacetime, test_photosphere, None, 1, mock_correction_function)
         
         
     def test_do_fast_getter_setter(self):
         # Initial state of _do_fast
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
         initial_value = False
-        self.HotRegion.do_fast = initial_value
+        test_hotregion.do_fast = initial_value
         
         # Test the getter
-        assert self.HotRegion.do_fast == initial_value, f"Expected {initial_value}, but got {self.HotRegion.do_fast}"
+        assert test_hotregion.do_fast == initial_value, f"Expected {initial_value}, but got {test_hotregion.do_fast}"
     
         # Test the setter
         new_value = True
-        self.HotRegion.do_fast = new_value
-        assert self.HotRegion.do_fast == new_value, f"Expected {new_value}, but got {self.HotRegion.do_fast}"
+        test_hotregion.do_fast = new_value
+        assert test_hotregion.do_fast == new_value, f"Expected {new_value}, but got {test_hotregion.do_fast}"
 
     def test_fast_mode_getter_setter(self):
         # Initial state of _do_fast
+        test_hotregion = HotRegion(bounds=self.hot_bounds, values=self.hot_values)
         initial_value = False
-        self.HotRegion.fast_mode = initial_value
+        test_hotregion.fast_mode = initial_value
         
         # Test the getter
-        assert self.HotRegion.fast_mode == initial_value, f"Expected {initial_value}, but got {self.HotRegion.do_fast}"
+        assert test_hotregion.fast_mode == initial_value, f"Expected {initial_value}, but got {test_hotregion.do_fast}"
     
         # Test the setter
         new_value = True
-        self.HotRegion.fast_mode = new_value
-        assert self.HotRegion.fast_mode == new_value, f"Expected {new_value}, but got {self.HotRegion.do_fast}"
+        test_hotregion.fast_mode = new_value
+        assert test_hotregion.fast_mode == new_value, f"Expected {new_value}, but got {test_hotregion.do_fast}"
 
     def test_cede_getter_setter(self):
         # Test with initial value of _cede
+        test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
         initial_value = False
-        self.HotRegion._cede = initial_value
+        test_hotregion._cede = initial_value
     
         # Test the getter
-        assert self.HotRegion.cede == initial_value, f"Expected {initial_value}, but got {self.HotRegion.cede}"
+        assert test_hotregion.cede == initial_value, f"Expected {initial_value}, but got {test_hotregion.cede}"
     
         # Test the setter with a valid boolean value (True)
-        self.HotRegion.cede = True
-        assert self.HotRegion.cede == True, f"Expected True, but got {self.HotRegion.cede}"
+        test_hotregion.cede = True
+        assert test_hotregion.cede == True, f"Expected True, but got {test_hotregion.cede}"
     
         # Test the setter with a valid boolean value (False)
-        self.HotRegion.cede = False
-        assert self.HotRegion.cede == False, f"Expected False, but got {self.HotRegion.cede}"
+        test_hotregion.cede = False
+        assert test_hotregion.cede == False, f"Expected False, but got {test_hotregion.cede}"
 
 
     def test_omit_getter_setter(self):
         # Test with initial value of _omit
+        test_hotregion = HotRegion(bounds=self.hot_bounds, values=self.hot_values)
         initial_value = False
-        self.HotRegion._omit = initial_value
+        test_hotregion._omit = initial_value
     
         # Test the getter
-        assert self.HotRegion.omit == initial_value, f"Expected {initial_value}, but got {self.HotRegion.omit}"
+        assert test_hotregion.omit == initial_value, f"Expected {initial_value}, but got {test_hotregion.omit}"
     
         # Test the setter with a valid boolean value (True)
-        self.HotRegion.omit = True
-        assert self.HotRegion.omit == True, f"Expected True, but got {self.HotRegion.omit}"
+        test_hotregion.omit = True
+        assert test_hotregion.omit == True, f"Expected True, but got {test_hotregion.omit}"
     
         # Test the setter with a valid boolean value (False)
-        self.HotRegion.omit = False
-        assert self.HotRegion.omit == False, f"Expected False, but got {self.HotRegion.omit}"
+        test_hotregion.omit = False
+        assert test_hotregion.omit == False, f"Expected False, but got {test_hotregion.omit}"
         
 
     def test_concentric_getter_setter(self):
         # Test with initial value of _concentric
+        test_hotregion = HotRegion(bounds=self.hot_bounds, values=self.hot_values)
         initial_value = False
-        self.HotRegion._concentric = initial_value
+        test_hotregion._concentric = initial_value
     
         # Test the getter
-        assert self.HotRegion.concentric == initial_value, f"Expected {initial_value}, but got {self.HotRegion.concentric}"
+        assert test_hotregion.concentric == initial_value, f"Expected {initial_value}, but got {test_hotregion.concentric}"
     
         # Test the setter with a valid boolean value (True)
-        self.HotRegion.concentric = True
-        assert self.HotRegion.concentric == True, f"Expected True, but got {self.HotRegion.concentric}"
+        test_hotregion.concentric = True
+        assert test_hotregion.concentric == True, f"Expected True, but got {test_hotregion.concentric}"
     
         # Test the setter with a valid boolean value (False)
-        self.HotRegion.concentric = False
-        assert self.HotRegion.concentric == False, f"Expected False, but got {self.HotRegion.concentric}"
+        test_hotregion.concentric = False
+        assert test_hotregion.concentric == False, f"Expected False, but got {test_hotregion.concentric}"
         
         
         
     def test_integrate_runs(self):
-        # Just testing that the embed function runs.
-        # split=False
-        # hot_region = HotRegion(self.hot_bounds, self.hot_values, split=split)
-        # hot_region.symmetry = True
-        # print(hot_region._integrator)
-        self.HotRegion.embed(self.Spacetime, self.Photosphere, None, 1)
+        # Just testing that the integrate function runs with default atmosphere. Not tested yet numerical atmospheres.
+       
+        test_hotregion = HotRegion(bounds=self.hot_bounds, values=self.hot_values)
+        test_spacetime = Spacetime(bounds=self.space_bounds, values=self.space_values)
+        test_photosphere = Photosphere(hot=test_hotregion, bounds={'mode_frequency': (None, None)}, values={'mode_frequency': self.space_values['frequency']})
+    
+        test_hotregion.fast_mode=False
+        test_hotregion.embed(test_spacetime, test_photosphere, None, 1)
         
-
-        # just testing if the integrate runs, first with the default BB 
-        # atmosphere given a hotregion and no elsewhere
-        hot_atmosphere = ()
-        elsewhere_atmosphere = ()
         atm_ext_else = None
         energies = np.linspace(1,2,10) # keV
-        self.HotRegion.integrate(self.Spacetime, energies, 1, hot_atmosphere, elsewhere_atmosphere, atm_ext_else)
+        test_hotregion.integrate(test_spacetime, energies, 1, test_photosphere.hot_atmosphere, test_photosphere.elsewhere_atmosphere, atm_ext_else)
         
+

--- a/xpsi/tests/test_hotregion.py
+++ b/xpsi/tests/test_hotregion.py
@@ -16,7 +16,8 @@ class TestHotRegion(object):
                       'super_temperature': cls.super_temperature_bounds,}
 	
         cls.values = {}
-        
+        cls.HotRegion = HotRegion(cls.bounds, cls.values)
+    
     def test_hotregion_class_initializes(self):
         HotRegion(self.bounds, self.values)
     
@@ -29,18 +30,59 @@ class TestHotRegion(object):
             HotRegion(self.bounds)
             
     def test_hotregion_breaks_if_phase_shift_bounds_unspecified(self):
-        self.bounds['phase_shift'] = (None, None)
+        bounds = self.bounds.copy()
+        bounds['phase_shift'] = (None, None)
         with pytest.raises(ValueError):
-            HotRegion(self.bounds, self.values)
+            HotRegion(bounds, self.values)
             
     def test_hotregion_breaks_if_phase_shift_bounds_infinite(self):
-        self.bounds['phase_shift'] = (-np.inf, np.inf)
+        bounds = self.bounds.copy()
+        bounds['phase_shift'] = (-np.inf, np.inf)
         with pytest.raises(ValueError):
-            HotRegion(self.bounds, self.values)
+            HotRegion(bounds, self.values)
             
     def test_hotregion_breaks_if_phase_shift_bounds_more_than_one_cycle(self):
-        self.bounds['phase_shift'] = (0, 1.1)
+        bounds = self.bounds.copy()
+        bounds['phase_shift'] = (0, 1.1)
         with pytest.raises(ValueError):
-            HotRegion(self.bounds, self.values)
+            HotRegion(bounds, self.values)
             
+    def test_hotregion_produces_default_parameters(self):
+        self.HotRegion.get_param('phase_shift')
+        self.HotRegion.get_param('super_colatitude')
+        self.HotRegion.get_param('super_radius')
+        self.HotRegion.get_param('super_temperature')
+        self.HotRegion.get_param('cede_colatitude')
+        self.HotRegion.get_param('cede_radius')
+        self.HotRegion.get_param('cede_azimuth')
+        self.HotRegion.get_param('omit_colatitude')
+        self.HotRegion.get_param('omit_radius')
+        self.HotRegion.get_param('omit_azimuth')
+        
+        
+    def test_hotregion_handles_cede(self):
+        bounds = self.bounds.copy()
+        bounds['cede_temperature'] = (5.1, 6.8)
+        HotRegionCede = HotRegion(bounds, self.values, cede = True)
+        HotRegionCede.get_param('cede_temperature')
+        
+    @pytest.mark.parametrize("inplace", [True, False])
+    def test_hotregion_sets_symmetry(self, inplace):
+        self.HotRegion.symmetry = inplace
+        
+    @pytest.mark.parametrize("declaration, split, expected_error", [
+    (True, False, None),                 # No error, symmetry=True, split=False
+    (False, False, None),                # No error, symmetry=False, split=False
+    (False, True, "TypeError"),          # Error, split=True, symmetry=False
+    ("invalid", False, "TypeError"),     # Error, invalid type for symmetry
+])
+    def test_symmetry(self, declaration, split, expected_error):
+        hot_region = HotRegion(self.bounds, self.values, split=split)
     
+        if expected_error:
+            with pytest.raises(eval(expected_error)):
+                hot_region.symmetry = declaration
+        else:
+            hot_region.symmetry = declaration
+            assert hot_region._integrator is not None
+            assert hot_region._integratorIQU is not None

--- a/xpsi/tests/test_hotregion.py
+++ b/xpsi/tests/test_hotregion.py
@@ -1,0 +1,46 @@
+import numpy as np
+from xpsi.HotRegion import HotRegion
+import pytest
+
+class TestHotRegion(object):
+    
+    def setup_class(cls):
+        cls.super_colatitude_bounds = (None, None)
+        cls.super_radius_bounds = (None, None)
+        cls.phase_shift_bounds = (0.0, 0.1)
+        cls.super_temperature_bounds = (5.1, 6.8)
+
+        cls.bounds = {'super_colatitude': cls.super_colatitude_bounds,
+                      'super_radius': cls.super_radius_bounds,
+                      'phase_shift': cls.phase_shift_bounds,
+                      'super_temperature': cls.super_temperature_bounds,}
+	
+        cls.values = {}
+        
+    def test_hotregion_class_initializes(self):
+        HotRegion(self.bounds, self.values)
+    
+    def test_hotregion_breaks_with_bounds_missing(self):
+        with pytest.raises(TypeError):
+            HotRegion(self.values)
+            
+    def test_hotregion_breaks_with_values_missing(self):
+        with pytest.raises(TypeError):
+            HotRegion(self.bounds)
+            
+    def test_hotregion_breaks_if_phase_shift_bounds_unspecified(self):
+        self.bounds['phase_shift'] = (None, None)
+        with pytest.raises(ValueError):
+            HotRegion(self.bounds, self.values)
+            
+    def test_hotregion_breaks_if_phase_shift_bounds_infinite(self):
+        self.bounds['phase_shift'] = (-np.inf, np.inf)
+        with pytest.raises(ValueError):
+            HotRegion(self.bounds, self.values)
+            
+    def test_hotregion_breaks_if_phase_shift_bounds_more_than_one_cycle(self):
+        self.bounds['phase_shift'] = (0, 1.1)
+        with pytest.raises(ValueError):
+            HotRegion(self.bounds, self.values)
+            
+    

--- a/xpsi/tests/test_hotregion.py
+++ b/xpsi/tests/test_hotregion.py
@@ -112,7 +112,7 @@ class TestHotRegion(object):
         test_hotregion=HotRegion(bounds=self.hot_bounds, values=self.hot_values)
         
         fast_num_rays = 50
-        if isinstance(num_rays, float | int):
+        if isinstance(num_rays, (float, int)):
             test_hotregion.set_num_rays(num_rays, fast_num_rays)
             assert test_hotregion.num_rays == int(num_rays), f"Expected num_rays to be {num_rays}, got {test_hotregion.num_rays}"
             assert test_hotregion._fast_num_rays == fast_num_rays, f"Expected _fast_num_rays to be {fast_num_rays}, got {test_hotregion._fast_num_rays}"    

--- a/xpsi/tests/test_hotregion.py
+++ b/xpsi/tests/test_hotregion.py
@@ -1,5 +1,6 @@
 import numpy as np
 from xpsi.HotRegion import HotRegion
+from xpsi.Spacetime import Spacetime
 import pytest
 
 class TestHotRegion(object):
@@ -10,42 +11,56 @@ class TestHotRegion(object):
         cls.phase_shift_bounds = (0.0, 0.1)
         cls.super_temperature_bounds = (5.1, 6.8)
 
-        cls.bounds = {'super_colatitude': cls.super_colatitude_bounds,
+        cls.hot_bounds = {'super_colatitude': cls.super_colatitude_bounds,
                       'super_radius': cls.super_radius_bounds,
                       'phase_shift': cls.phase_shift_bounds,
                       'super_temperature': cls.super_temperature_bounds,}
 	
-        cls.values = {}
-        cls.HotRegion = HotRegion(cls.bounds, cls.values)
+        cls.hot_values = {}
+        cls.HotRegion = HotRegion(cls.hot_bounds, cls.hot_values)
+        cls.space_values = {'frequency': 401., #Hz
+                            'distance': 5., #kpc
+                            'mass': 2., #Msun
+                            'radius': 10., #km
+                            'cos_inclination': 0.5
+                            }
+        cls.space_bounds = {'frequency': (None, None), #Hz
+                            'distance': (None, None), #kpc
+                            'mass': (None, None), #Msun
+                            'radius': (None, None), #km
+                            'cos_inclination': (None, None)
+                            }
+        
+        cls.Spacetime = Spacetime(bounds=cls.space_bounds, values=cls.space_values)
     
     def test_hotregion_class_initializes(self):
-        HotRegion(self.bounds, self.values)
+        HotRegion(self.hot_bounds, self.hot_values)
     
     def test_hotregion_breaks_with_bounds_missing(self):
         with pytest.raises(TypeError):
-            HotRegion(self.values)
+            HotRegion(self.hot_values)
             
     def test_hotregion_breaks_with_values_missing(self):
         with pytest.raises(TypeError):
-            HotRegion(self.bounds)
+            HotRegion(self.hot_bounds)
             
     def test_hotregion_breaks_if_phase_shift_bounds_unspecified(self):
-        bounds = self.bounds.copy()
+        bounds = self.hot_bounds.copy()
         bounds['phase_shift'] = (None, None)
         with pytest.raises(ValueError):
-            HotRegion(bounds, self.values)
+            HotRegion(bounds, self.hot_values)
             
     def test_hotregion_breaks_if_phase_shift_bounds_infinite(self):
-        bounds = self.bounds.copy()
+        bounds = self.hot_bounds.copy()
         bounds['phase_shift'] = (-np.inf, np.inf)
         with pytest.raises(ValueError):
-            HotRegion(bounds, self.values)
+            HotRegion(bounds, self.hot_values)
             
     def test_hotregion_breaks_if_phase_shift_bounds_more_than_one_cycle(self):
-        bounds = self.bounds.copy()
+        bounds = self.hot_bounds.copy()
         bounds['phase_shift'] = (0, 1.1)
         with pytest.raises(ValueError):
-            HotRegion(bounds, self.values)
+            HotRegion(bounds, self.hot_values)
             
     def test_hotregion_produces_default_parameters(self):
         self.HotRegion.get_param('phase_shift')
@@ -61,14 +76,10 @@ class TestHotRegion(object):
         
         
     def test_hotregion_handles_cede(self):
-        bounds = self.bounds.copy()
+        bounds = self.hot_bounds.copy()
         bounds['cede_temperature'] = (5.1, 6.8)
-        HotRegionCede = HotRegion(bounds, self.values, cede = True)
+        HotRegionCede = HotRegion(bounds, self.hot_values, cede = True)
         HotRegionCede.get_param('cede_temperature')
-        
-    @pytest.mark.parametrize("inplace", [True, False])
-    def test_hotregion_sets_symmetry(self, inplace):
-        self.HotRegion.symmetry = inplace
         
     @pytest.mark.parametrize("declaration, split, expected_error", [
     (True, False, None),                 # No error, symmetry=True, split=False
@@ -77,7 +88,7 @@ class TestHotRegion(object):
     ("invalid", False, "TypeError"),     # Error, invalid type for symmetry
 ])
     def test_symmetry(self, declaration, split, expected_error):
-        hot_region = HotRegion(self.bounds, self.values, split=split)
+        hot_region = HotRegion(self.hot_bounds, self.hot_values, split=split)
     
         if expected_error:
             with pytest.raises(eval(expected_error)):
@@ -86,3 +97,274 @@ class TestHotRegion(object):
             hot_region.symmetry = declaration
             assert hot_region._integrator is not None
             assert hot_region._integratorIQU is not None
+            
+    @pytest.mark.parametrize("num_rays", [50, 50.5, "invalid"])
+    def test_set_num_rays(self, num_rays):
+        # Test that integer, float and invalid values for num_rays have corect set and get. Raise error if invalid.
+        
+        fast_num_rays = 50
+        if isinstance(num_rays, float | int):
+            self.HotRegion.set_num_rays(num_rays, fast_num_rays)
+            assert self.HotRegion.num_rays == int(num_rays), f"Expected num_rays to be {num_rays}, got {self.HotRegion.num_rays}"
+            assert self.HotRegion._fast_num_rays == fast_num_rays, f"Expected _fast_num_rays to be {fast_num_rays}, got {self.HotRegion._fast_num_rays}"    
+        else:
+            with pytest.raises(ValueError):
+                self.HotRegion.set_num_rays(num_rays, fast_num_rays)
+                
+    def test_image_order_limit_getter(self):
+        # Set a value directly to the private attribute
+        self.HotRegion._image_order_limit = 5
+    
+        # Validate the getter returns the correct value
+        assert self.HotRegion.image_order_limit == 5, (
+            f"Expected image_order_limit to be 5, but got {self.HotRegion.image_order_limit}"
+        )
+
+    @pytest.mark.parametrize("image_order_limit", [10, None, "invalid", 3.5])
+    def test_image_order_limit_setter_valid(self, image_order_limit):
+        # Test with a positive integer
+        if image_order_limit == 10:
+            self.HotRegion.image_order_limit = 10
+            assert self.HotRegion._image_order_limit == 10, (
+                f"Expected _image_order_limit to be 10, but got {self.HotRegion._image_order_limit}"
+            )
+        elif image_order_limit == None:
+            self.HotRegion.image_order_limit = None
+            assert self.HotRegion._image_order_limit is None, (
+                f"Expected _image_order_limit to be None, but got {self.HotRegion._image_order_limit}"
+            )
+        elif image_order_limit == "invalid":
+            # Test with a non-integer value
+            with pytest.raises(TypeError, match="Image order limit must be an positive integer if not None."):
+                self.HotRegion.image_order_limit = "invalid"
+        elif image_order_limit == 3.5:
+            with pytest.raises(TypeError, match="Image order limit must be an positive integer if not None."):
+                self.HotRegion.image_order_limit = 3.5
+
+    @pytest.mark.parametrize(
+        "sqrt_num_cells, min_sqrt_num_cells, max_sqrt_num_cells, fast_sqrt_num_cells, fast_min_sqrt_num_cells, fast_max_sqrt_num_cells, expect_error",
+        [
+            # Valid cases
+            (32, 10, 80, 16, 4, 16, None),           # Standard valid input
+            (4, 4, 4, 4, 4, 4, None),               # Minimal valid input
+            (80, 10, 80, 16, 4, 16, None),          # Edge of max valid
+
+            # Invalid cases
+            (3, 10, 80, 16, 4, 16, ValueError),     # sqrt_num_cells < 4
+            ("invalid", 10, 80, 16, 4, 16, ValueError), # Non-integer sqrt_num_cells
+            (32, 80, 10, 16, 4, 16, AssertionError), # min > max for regular cells
+            (32, 10, 80, 16, 16, 4, AssertionError), # min > max for fast cells
+        ],
+    )
+    def test_set_num_cells(self, sqrt_num_cells, min_sqrt_num_cells, max_sqrt_num_cells,
+                           fast_sqrt_num_cells, fast_min_sqrt_num_cells, fast_max_sqrt_num_cells,
+                           expect_error):
+        if expect_error:
+            with pytest.raises(expect_error):
+                self.HotRegion.set_num_cells(
+                    sqrt_num_cells, min_sqrt_num_cells, max_sqrt_num_cells,
+                    fast_sqrt_num_cells, fast_min_sqrt_num_cells, fast_max_sqrt_num_cells
+                )
+        else:
+            self.HotRegion.set_num_cells(
+                sqrt_num_cells, min_sqrt_num_cells, max_sqrt_num_cells,
+                fast_sqrt_num_cells, fast_min_sqrt_num_cells, fast_max_sqrt_num_cells
+            )
+
+            # Validate attributes for regular cells
+            assert self.HotRegion.sqrt_num_cells == sqrt_num_cells
+            assert self.HotRegion._num_cells == sqrt_num_cells**2
+            assert self.HotRegion._min_sqrt_num_cells == min_sqrt_num_cells
+            assert self.HotRegion._max_sqrt_num_cells == max_sqrt_num_cells
+
+            # Validate attributes for fast cells
+            assert self.HotRegion._fast_num_cells == fast_sqrt_num_cells**2
+            assert self.HotRegion._fast_min_sqrt_num_cells == fast_min_sqrt_num_cells
+            assert self.HotRegion._fast_max_sqrt_num_cells == fast_max_sqrt_num_cells
+
+    def test_leaves_property(self):
+        # Set a value directly to the private attribute
+        self.HotRegion._leaves = "test_value"
+
+        # Verify that the property returns the correct value
+        assert self.HotRegion.leaves == "test_value", (
+            f"Expected leaves to return 'test_value', but got {self.HotRegion.leaves}"
+        )
+        
+    @pytest.mark.parametrize(
+        "num_leaves, num_phases, phases, fast_num_leaves, fast_num_phases, fast_phases, do_fast, expect_error",
+        [
+            # Valid cases not fast
+            (5, None, None, None, None, None, False, None),
+            (5, None, np.linspace(0, 1, 5), None, None, None, False, None),
+            (5, 6, None, None, None, None, False, None),
+            (5, None, np.linspace(0, 1, 5), None, None, None, False, None),
+            
+            
+            # Invalid cases
+            (None, None, None, None, None, None, False, TypeError), # not allowed no leaves
+            (5, "not_a_number", None, None, None, None, False, ValueError), # not allowed invalid num_phases
+            (5, None, "not_an_array", None, None, None, False, TypeError), # not allowed invalid phases
+            (5, None, np.array([0, 2, 1]), None, None, None, False, TypeError), # non monotonical
+            (5, None, np.array([-0.1, 0.5, 1]), None, None, None, False, TypeError), # negative
+            (5, None, np.array([0, 0.5, 1.1]), None, None, None, False, TypeError), # more than 1
+
+            
+            # Fast valid cases
+            (5, None, None, 5, None, None, True, None),
+            (5, None, np.linspace(0, 1, 5), 5, None, np.linspace(0, 1, 5), True, None),
+            (5, 6, None, 5, 6, None, True, None),
+            (5, None, np.linspace(0, 1, 5), 5, 6, np.linspace(0, 1, 5), True, None),
+            
+            # Fast invalid cases
+            (5, None, None, None, None, None, True, TypeError), # not allowed no leaves
+            (5, None, None, 5, "not_a_number", None, True, ValueError), # not allowed invalid num_phases
+            (5, None, None, 5, None, "not_an_array", True, TypeError), # not allowed invalid phases
+            (5, None, None, 5, None, np.array([0, 2, 1]), True, TypeError), # non monotonical
+            (5, None, None, 5, None, np.array([-0.1, 0.5, 1]), True, TypeError), # negative
+            (5, None, None, 5, None, np.array([0, 0.5, 1.1]), True, TypeError), # more than 1
+        ]
+    )
+    def test_set_phases(self,num_leaves, num_phases, phases, fast_num_leaves, fast_num_phases, fast_phases, do_fast, expect_error):    
+        HotRegion.do_fast = do_fast
+        # Expect error for invalid cases
+        if expect_error:
+            with pytest.raises(expect_error):
+                self.HotRegion.set_phases(num_leaves, num_phases=num_phases, phases=phases, fast_num_leaves=fast_num_leaves, fast_num_phases=fast_num_phases, fast_phases=fast_phases)
+        else:
+            # Test valid cases
+            self.HotRegion.set_phases(num_leaves, num_phases=num_phases, phases=phases, fast_num_leaves=fast_num_leaves, fast_num_phases=fast_num_phases, fast_phases=fast_phases)
+            if phases is None and num_phases is None:
+                num_temp = num_leaves
+                linspace_temp = np.linspace(0, 1, num_temp)
+            elif phases is None:
+                num_temp = num_phases
+                linspace_temp = np.linspace(0, 1, num_temp)
+            else:
+                linspace_temp = phases
+            
+            assert np.allclose(self.HotRegion._phases_cycles, linspace_temp), f"Expected phases {linspace_temp}, but got {self.HotRegion._phases_cycles}"
+            assert np.allclose(self.HotRegion._leaves, np.linspace(0.0, 2*np.pi, 5)), f"Expected leaves to be np.linspace(0.0, 2*np.pi, 5), but got {self.HotRegion._leaves}"
+            
+        #HotRegion.do_fast = False # restore
+        
+        
+    def test_phases_in_cycles_property(self):
+        # Set a value directly to the private attribute
+        self.HotRegion._phases_cycles = "test_value"
+        self.HotRegion._fast_phases_cycles = "test_value"
+
+        # Verify that the property returns the correct value
+        assert self.HotRegion.phases_in_cycles == "test_value", (
+            f"Expected phases_in_cycles to return 'test_value', but got {self.HotRegion.phases_in_cycles}"
+        )
+        assert self.HotRegion.fast_phases_in_cycles == "test_value", (
+            f"Expected fast_phases_in_cycles to return 'test_value', but got {self.HotRegion.fast_phases_in_cycles}"
+        )
+        
+    def test_num_cells_property(self):
+        # Set a value directly to the private attribute
+        self.HotRegion._num_cells = "test_value"
+
+        # Verify that the property returns the correct value
+        assert self.HotRegion.num_cells == "test_value", (
+            f"Expected num_cells to return 'test_value', but got {self.HotRegion.num_cells}"
+        )
+        
+        
+    @pytest.mark.parametrize(
+        "input_value, expected_value, expect_error",
+        [
+            # Valid cases
+            (True, True, None),  # Set True
+            (False, False, None),  # Set False
+            
+            # Invalid cases
+            (1, None, TypeError),  # Non-boolean integer
+            ("True", None, TypeError),  # Non-boolean string
+            (None, None, TypeError),  # None is invalid
+        ]
+    )
+    def test_is_antiphased(self, input_value, expected_value, expect_error):
+    
+        # Handle invalid cases
+        if expect_error:
+            with pytest.raises(expect_error):
+                self.HotRegion.is_antiphased = input_value
+        else:
+            # Set the value
+            self.HotRegion.is_antiphased = input_value
+            
+            # Assert getter returns the correct value
+            assert self.HotRegion.is_antiphased == expected_value, f"Expected {expected_value}, but got {self.HotRegion.is_antiphased}"
+
+    @pytest.mark.parametrize(
+        "input_extension, expected_value, expect_error",
+        [
+            # Valid cases
+            ("BB", 1, None),
+            ("Num4D", 2, None),
+            ("Pol_BB_Burst", 3, None),
+            ("Pol_Num2D", 4, None),
+            ("user", 5, None),
+            ("Num5D", 6, None),
+    
+            # Invalid cases
+            ("InvalidExt", None, TypeError),  # Not a recognized string
+            (123, None, TypeError),          # Non-string input
+            (None, None, TypeError),         # None is invalid
+        ]
+    )
+    def test_atm_ext(self, input_extension, expected_value, expect_error):
+        # For invalid cases, assert that the proper exception is raised
+        if expect_error:
+            with pytest.raises(expect_error):
+                self.HotRegion.atm_ext = input_extension
+        else:
+            # Set the value
+            self.HotRegion.atm_ext = input_extension
+            
+            # Assert the getter returns the correct value
+            assert self.HotRegion.atm_ext == expected_value, f"Expected {expected_value}, but got {self.HotRegion.atm_ext}"
+    
+    
+    @pytest.mark.parametrize(
+        "input_option, expected_value, expect_error",
+        [
+            # Valid cases
+            (0, 0, None),
+            (1, 1, None),
+            (2, 2, None),
+            (3, 3, None),
+    
+            # Invalid cases
+            (4, None, TypeError),      # Not in the valid range
+            (-1, None, TypeError),     # Negative value
+            ("1", None, TypeError),    # Non-integer input
+            (None, None, TypeError),   # None is invalid
+        ]
+    )
+    def test_beam_opt(self, input_option, expected_value, expect_error):
+        # For invalid cases, assert that the proper exception is raised
+        if expect_error:
+            with pytest.raises(expect_error):
+                self.HotRegion.beam_opt = input_option
+        else:
+            # Set the value
+            self.HotRegion.beam_opt = input_option
+            
+            # Assert the getter returns the correct value
+            assert self.HotRegion.beam_opt == expected_value, f"Expected {expected_value}, but got {self.HotRegion.beam_opt}"
+
+    def test_print_settings(self, capfd):
+        # Call the method
+        self.HotRegion.print_settings()
+        
+        # Capture the output
+        captured = capfd.readouterr()
+        
+        # Assert that something was printed
+        assert captured.out != "", "Expected some output, but nothing was printed."
+
+    # def test_construct_cellmesh(self):
+        

--- a/xpsi/tests/test_hotregions.py
+++ b/xpsi/tests/test_hotregions.py
@@ -1,0 +1,30 @@
+import numpy as np
+from xpsi.HotRegion import HotRegion
+from xpsi.HotRegions import HotRegions
+import pytest
+
+class TestHotRegions(object):
+    
+    def setup_class(cls):
+        cls.super_colatitude_bounds = (None, None)
+        cls.super_radius_bounds = (None, None)
+        cls.phase_shift_bounds = (0.0, 0.1)
+        cls.super_temperature_bounds = (5.1, 6.8)
+
+        cls.bounds = {'super_colatitude': cls.super_colatitude_bounds,
+                      'super_radius': cls.super_radius_bounds,
+                      'phase_shift': cls.phase_shift_bounds,
+                      'super_temperature': cls.super_temperature_bounds,}
+	
+        cls.values = {}
+        
+        cls.primary = HotRegion(cls.bounds, cls.values, prefix='p')
+        cls.secondary = HotRegion(cls.bounds, cls.values, prefix='s')
+        
+    def test_hotregions_class_initializes(self):
+        hrs = HotRegions((self.primary, self.secondary))
+        
+    def test_hotregions_breaks_with_one_hotregion(self):
+        with pytest.raises(ValueError):
+            hrs = HotRegions((self.primary))
+

--- a/xpsi/tests/test_likelihood.py
+++ b/xpsi/tests/test_likelihood.py
@@ -102,7 +102,7 @@ class TestLikelihoodCheck(object):
 	                                    max_sqrt_num_cells=64,
 	                                    num_leaves=64,
 	                                    num_rays=512,
-	                                    is_secondary=True,
+                                        is_antiphased=True,
 	                                    image_order_limit=3, # up to tertiary
 	                                    prefix='hot')
 


### PR DESCRIPTION
Here I added basic run, getter and setter tests for all functions in hotregion.py

However, not every reasonable model configuration has been tested. For example, I am not testing ceding and omitting hot spots and numerical atmospheres yet. Best would be to also add some asserts to ensure that the correct values come out. Still, the tests we have so far can be checked and merged in my opinion.

Here I also deprecate the `is_secondary` keyword argument in the HotRegion class. So if this issue is closed that other issue can also be closed.