### PR TITLE
Update years and stop assigning all tasks to Tom by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: "[Feature]"
 labels: enhancement
-assignees: ThomasEdwardRiley
+assignees: 
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022 the X-PSI core team
+Copyright (c) 2022-2025 the X-PSI core team
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,7 +70,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'x-psi'
-copyright = '2019-2023 the X-PSI Core Team'
+copyright = '2019-2025 the X-PSI Core Team'
 author = 'X-PSI Core Team'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Update copyright years and remove Tom as default assignee for features! 