### PR TITLE
Import order issue moved to FAQ.

### DIFF
--- a/docs/source/FAQ.rst
+++ b/docs/source/FAQ.rst
@@ -97,3 +97,10 @@ Make sure to to install nestcheck and GetDist packages using the corresponding g
 .. rubric:: *ValueError: There is more than one signal instance.*
 
 Typically occurs when post-processing joint NICER and XMM results, if not setting ``model.likelihood.signals = model.likelihood.signals[0][0]`` (when plotting the inferred NICER signal).
+
+Weird issues
+^^^^^^^^^^^^
+
+.. rubric:: *The import order of pymultinest and numpy may sometimes affect the seed-fixed results.*
+
+The import order of numpy and X-PSI (and thus pymultinest) was observed to sometimes influence the exact sampling results even if fixing the random seeds for both numpy and pymultinest. However, the issue occurred only in specific conda environments (with certain packages/dependencies) and later attempts to reproduce it with newer X-PSI installations have not been successful. See the `GitHub issue <https://github.com/xpsi-group/xpsi/issues/276>`_ for more details.


### PR DESCRIPTION
As discussed during the hack week, I added information about the import order issue of numpy and pymultinest to the FAQ pages so that the GitHub issue can be closed. 

I also tried to reproduce the issue with newer X-PSI installations (both X-PSI v3.0.0 and v1.2.1 with newest dependencies), but I was not able to do that. Instead, the import order did not seem to affect the results at all (which I think makes more sense). I mentioned this also in the FAQ. I could not either reproduce the issue with the exact packages that were reported in the original issue, since my current laptop does not have an old enough version of gcc.