### PR TITLE
Updating GitHub workflows to use newer gcc

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -53,7 +53,7 @@ jobs:
         python setup.py install
       shell: bash -l {0}
       env:
-        CC:   gcc-10
+        CC:   gcc-12
     - name : build docs
       run: | 
         make html

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -54,7 +54,7 @@ jobs:
         python setup.py install
       shell: bash -l {0}
       env:
-        CC:   gcc-10
+        CC:   gcc-12
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
As discussed in https://github.com/xpsi-group/xpsi/pull/506, newer gcc version is needed for the GitHub Action workflows when installing X-PSI, because the latest default Ubuntu version has upgraded and has no gcc-10 anymore.