### PR TITLE
Merging the updated main branch to the accretion disk tutorial branch

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -53,7 +53,7 @@ jobs:
         python setup.py install
       shell: bash -l {0}
       env:
-        CC:   gcc-10
+        CC:   gcc-12
     - name : build docs
       run: | 
         make html

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
         python setup.py install
       shell: bash -l {0}
       env:
-        CC:   gcc-10
+        CC:   gcc-12
 
     - name: Test with pytest
       run: |


### PR DESCRIPTION
* Change to gcc-12 for CI tests

* Do testing also with Py3.12

* Use gcc-12 in build_docs