### PR TITLE
523 speed up post processing

### DIFF
--- a/xpsi/PostProcessing/_backends.py
+++ b/xpsi/PostProcessing/_backends.py
@@ -39,6 +39,7 @@ class NestedBackend(Run):
         filerootpath =_os.path.join(base_dir, root)
         _filerootpath = filerootpath
 
+        # check whether to use .npy files or .txt files 
         if _os.path.isfile(filerootpath+'.npy'):
             loader = _np.load
             saver = _np.save
@@ -83,7 +84,7 @@ class NestedBackend(Run):
 
         if self.use_nestcheck and transform is not None:
             for ext in [f'dead-birth{filetype}', f'phys_live-birth{filetype}']:
-                # dead and live points later in process_multinest_run() for nestcheck:
+                # save dead and live points for later use in process_multinest_run():
                 if 'dead-birth' in ext: 
                     dead_points = samples
                 if 'phys_live-birth' in ext: 

--- a/xpsi/PostProcessing/_nestcheck_modifications.py
+++ b/xpsi/PostProcessing/_nestcheck_modifications.py
@@ -1,6 +1,8 @@
 import getdist
 import getdist.plots
 getdist.chains.print_load_details = False
+from ._global_imports import *
+from nestcheck.data_processing import process_samples_array
 
 def getdist_kde(x, samples, weights, **kwargs):
     """
@@ -32,3 +34,48 @@ def getdist_kde(x, samples, weights, **kwargs):
         bcknd.get1DDensity('x').normalize(by='integral',
                                                in_place=True)
     return bcknd.get1DDensity('x').Prob(x)
+
+def process_multinest_run(dead_points, live_points, file_root, base_dir, **kwargs):
+    """Modified version of nestcheck.data_processing.process_multinest_run().
+    Loads data (both .txt and .npy) from a MultiNest run into the nestcheck 
+    dictionary format for analysis.
+
+    N.B. producing required output file containing information about the
+    iso-likelihood contours within which points were sampled (where they were
+    "born") requies MultiNest version 3.11 or later.
+
+    Parameters
+    ----------
+    dead_points: ndarray
+        Dead points 
+    live_points: ndarray
+        Live points 
+    file_root: str
+        Root name for output files. When running MultiNest, this is determined
+        by the nest_root parameter.
+    base_dir: str
+        Directory containing output files. When running MultiNest, this is
+        determined by the nest_root parameter.
+    kwargs: dict, optional
+        Passed to ns_run_utils.check_ns_run (via process_samples_array)
+
+
+    Returns
+    -------
+    ns_run: dict
+        Nested sampling run dict (see the module docstring for more details).
+    """
+    # Remove unnecessary final columns
+    dead_points = dead_points[:, :-2]
+    live_points = live_points[:, :-1]
+    assert dead_points[:, -2].max() < live_points[:, -2].min(), (
+        'final live points should have greater logls than any dead point!',
+        dead_points, live_points)
+    ns_run = process_samples_array(_np.vstack((dead_points, live_points)), **kwargs)
+    assert _np.all(ns_run['thread_min_max'][:, 0] == -_np.inf), (
+        'As MultiNest does not currently perform dynamic nested sampling, all '
+        'threads should start by sampling the whole prior.')
+    ns_run['output'] = {}
+    ns_run['output']['file_root'] = file_root
+    ns_run['output']['base_dir'] = base_dir
+    return ns_run

--- a/xpsi/PostProcessing/_nestcheck_modifications.py
+++ b/xpsi/PostProcessing/_nestcheck_modifications.py
@@ -59,7 +59,6 @@ def process_multinest_run(dead_points, live_points, file_root, base_dir, **kwarg
     kwargs: dict, optional
         Passed to ns_run_utils.check_ns_run (via process_samples_array)
 
-
     Returns
     -------
     ns_run: dict

--- a/xpsi/PostProcessing/_run.py
+++ b/xpsi/PostProcessing/_run.py
@@ -25,7 +25,10 @@ class Run(Metadata):
         if _os.path.isfile(filepath):
             # we should be able to load samples straightforwardly into
             # a NumPy array for the most basic type of sample lookup
-            self._samples = _np.loadtxt(filepath)
+            if filepath.endswith(".npy"):
+                self._samples = _np.load(filepath)
+            elif filepath.endswith(".txt"):
+                self._samples = _np.loadtxt(filepath)
         else:
             raise ValueError('File %s does not exist.' % filepath)
 


### PR DESCRIPTION
To post-process the data, you can now also use .npy files, which is (a lot) faster than .txt files. Additionally, I changed the structure of the `PostProcessing/_backends.py` to increase readability, and to ensure that each file only gets loaded once (instead of multiple times as before). The latter is also the reason why we now have our own modified `process_multinest_run()` in `._nestcheck_modifications` instead of loading it from `nestcheck.data_processing` itself. 