### PR TITLE
547 Module generator: update generate.ini to load fits or txt files

### DIFF
--- a/xpsi/module_generator.py
+++ b/xpsi/module_generator.py
@@ -205,6 +205,13 @@ parser.add_argument('--frequency',
                     required=True,
                     help='The coordinate spin frequency of the star (Hz).',
                     empty_lines_below=2)
+                    
+parser.add_argument('--format',
+                    type=str,
+                    required=True,
+                    help='Format of the source files and reponse files, e.g., txt or fits',
+                    comment_line_above='input file flags',
+                    empty_lines_below=2)
 
 parser.add_argument('--model',
                     type=str,


### PR DESCRIPTION
Now generate.ini contain a new argument "-format" which can be set to either "txt" or "fits"

<img width="462" alt="Screenshot 2025-05-12 at 15 10 34" src="https://github.com/user-attachments/assets/f7e3e0c5-1747-422c-a6e7-b300c284c597" />
