### PR TITLE
Cython double==double comparisons made approximate

### DIFF
--- a/xpsi/cellmesh/integrator.pyx
+++ b/xpsi/cellmesh/integrator.pyx
@@ -41,6 +41,7 @@ from xpsi.surface_radiation_field.elsewhere_wrapper cimport (init_elsewhere,
                                                      eval_elsewhere_norm)
 
 from .rays cimport eval_image_deflection
+from ..tools.core cimport are_equal
 
 from ..tools.core cimport _get_phase_interpolant, gsl_interp_type
 
@@ -316,7 +317,7 @@ def integrate(size_t numThreads,
                 psi = eval_image_deflection(I, acos(cos_psi))
                 sin_psi = sin(psi)
 
-                if psi != 0.0 and sin_psi == 0.0: # sinularity at poles
+                if not are_equal(psi, 0.0) and are_equal(sin_psi, 0.0): # singularity at poles
                     # hack bypass by slight change of viewing angle
                     if cos_i >= 0.0:
                         _i = inclination + inclination * 1.0e-6 # arbitrary small

--- a/xpsi/cellmesh/integrator.pyx
+++ b/xpsi/cellmesh/integrator.pyx
@@ -349,7 +349,7 @@ def integrate(size_t numThreads,
                     sin_alpha = sqrt(1.0 - _cos_alpha * _cos_alpha)
                     mu = _cos_alpha * cos_gamma
 
-                    if psi != 0.0:
+                    if not are_equal(psi, 0.0):
                         cos_delta = (cos_i - cos_theta_i * cos_psi) / (sin_theta_i * sin_psi)
                         if theta_i_over_pi < 0.5:
                             mu = mu + sin_alpha * sin_gamma * cos_delta
@@ -383,7 +383,7 @@ def integrate(size_t numThreads,
                                 else:
                                     _kdx = N_L - 1 - k # switch due to symmetry
 
-                                if psi != 0.0:
+                                if not are_equal(psi, 0.0):
                                     cos_xi = sin_alpha * sin_i * sin(leaves[_kdx]) / sin_psi
                                     superlum = (1.0 + beta * cos_xi)
                                     eta = Lorentz / superlum

--- a/xpsi/cellmesh/integratorIQU.pyx
+++ b/xpsi/cellmesh/integratorIQU.pyx
@@ -372,7 +372,7 @@ def integrate(size_t numThreads,
                     sin_alpha = sqrt(1.0 - _cos_alpha * _cos_alpha)
                     mu = _cos_alpha * cos_gamma
 
-                    if psi != 0.0:
+                    if not are_equal(psi, 0.0):
                         cos_delta = (cos_i - cos_theta_i * cos_psi) / (sin_theta_i * sin_psi)
                         if theta_i_over_pi < 0.5:
                             mu = mu + sin_alpha * sin_gamma * cos_delta
@@ -406,7 +406,7 @@ def integrate(size_t numThreads,
                                 else:
                                     _kdx = N_L - 1 - k # switch due to symmetry
 
-                                if psi != 0.0:
+                                if not are_equal(psi, 0.0):
                                     cos_xi = sin_alpha * sin_i * sin(leaves[_kdx]) / sin_psi
                                     superlum = (1.0 + beta * cos_xi)
                                     eta = Lorentz / superlum

--- a/xpsi/cellmesh/integratorIQU.pyx
+++ b/xpsi/cellmesh/integratorIQU.pyx
@@ -43,6 +43,7 @@ from xpsi.surface_radiation_field.elsewhere_wrapper cimport (init_elsewhere,
                                                      eval_elsewhere_norm)
 
 from .rays cimport eval_image_deflection
+from ..tools.core cimport are_equal
 
 from ..tools.core cimport _get_phase_interpolant, gsl_interp_type
 
@@ -339,7 +340,7 @@ def integrate(size_t numThreads,
                 psi = eval_image_deflection(I, acos(cos_psi))
                 sin_psi = sin(psi)
 
-                if psi != 0.0 and sin_psi == 0.0: # sinularity at poles
+                if not are_equal(psi, 0.0) and are_equal(sin_psi, 0.0): # singularity at poles
                     # hack bypass by slight change of viewing angle
                     if cos_i >= 0.0:
                         _i = inclination + inclination * 1.0e-6 # arbitrary small

--- a/xpsi/cellmesh/integratorIQU_for_azimuthal_invariance.pyx
+++ b/xpsi/cellmesh/integratorIQU_for_azimuthal_invariance.pyx
@@ -45,6 +45,7 @@ ctypedef gsl_interp_accel accel
 ctypedef gsl_interp interp
 
 from .rays cimport eval_image_deflection
+from ..tools.core cimport are_equal
 
 from xpsi.surface_radiation_field.preload cimport (_preloaded,
                                                    init_preload,
@@ -363,7 +364,7 @@ def integrate(size_t numThreads,
                 psi = eval_image_deflection(I, acos(cos_psi))
                 sin_psi = sin(psi)
 
-                if psi != 0.0 and sin_psi == 0.0: # singularity at poles
+                if not are_equal(psi, 0.0) and are_equal(sin_psi, 0.0): # singularity at poles
                     # hack bypass by slight change of viewing angle
                     printf("sinpsi = %.6e\n", sin_psi)
                     printf("psi = %.6e\n", psi)

--- a/xpsi/cellmesh/integratorIQU_for_azimuthal_invariance.pyx
+++ b/xpsi/cellmesh/integratorIQU_for_azimuthal_invariance.pyx
@@ -401,7 +401,7 @@ def integrate(size_t numThreads,
                     # for spherical stars mu is defined, but for tilted local
                     # surface, there is not one unique value for mu because
                     # Einstein ring(s)
-                    if psi != 0.0:
+                    if not are_equal(psi, 0.0):
                         cos_delta = (cos_i - cos_theta_i * cos_psi) / (sin_theta_i * sin_psi)
                         if theta_i_over_pi < 0.5:
                             mu = mu + sin_alpha * sin_gamma * cos_delta
@@ -436,7 +436,7 @@ def integrate(size_t numThreads,
                                     _kdx = N_L - 1 - k # switch due to symmetry
 
                                 # phase asymmetric now
-                                if psi != 0.0:
+                                if not are_equal(psi, 0.0):
                                     cos_xi = sin_alpha * sin_i * sin(leaves[_kdx]) / sin_psi
                                     superlum = (1.0 + beta * cos_xi)
                                     eta = Lorentz / superlum

--- a/xpsi/cellmesh/integratorIQU_for_azimuthal_invariance_split.pyx
+++ b/xpsi/cellmesh/integratorIQU_for_azimuthal_invariance_split.pyx
@@ -44,6 +44,7 @@ ctypedef gsl_interp_accel accel
 ctypedef gsl_interp interp
 
 from .rays cimport eval_image_deflection
+from ..tools.core cimport are_equal
 
 from xpsi.surface_radiation_field.preload cimport (_preloaded,
                                                    init_preload,
@@ -386,7 +387,7 @@ def integrate(size_t numThreads,
                 psi = eval_image_deflection(I, acos(cos_psi))
                 sin_psi = sin(psi)
 
-                if psi != 0.0 and sin_psi == 0.0: # singularity at poles
+                if not are_equal(psi, 0.0) and are_equal(sin_psi, 0.0): # singularity at poles
                     # hack bypass by slight change of viewing angle
                     if cos_i >= 0.0:
                         _i = inclination + inclination * 1.0e-6 # arbitrary small

--- a/xpsi/cellmesh/integratorIQU_for_azimuthal_invariance_split.pyx
+++ b/xpsi/cellmesh/integratorIQU_for_azimuthal_invariance_split.pyx
@@ -422,7 +422,7 @@ def integrate(size_t numThreads,
                     # for spherical stars mu is defined, but for tilted local
                     # surface, there is not one unique value for mu because
                     # Einstein ring(s)
-                    if psi != 0.0:
+                    if not are_equal(psi, 0.0):
                         cos_delta = (cos_i - cos_theta_i * cos_psi) / (sin_theta_i * sin_psi)
                         if theta_i_over_pi < 0.5:
                             mu = mu + sin_alpha * sin_gamma * cos_delta
@@ -457,7 +457,7 @@ def integrate(size_t numThreads,
                                     _kdx = N_L - 1 - k # switch due to symmetry
 
                                 # phase asymmetric now
-                                if psi != 0.0:
+                                if not are_equal(psi, 0.0):
                                     cos_xi = sin_alpha * sin_i * sin(leaves[_kdx]) / sin_psi
                                     superlum = (1.0 + beta * cos_xi)
                                     eta = Lorentz / superlum

--- a/xpsi/cellmesh/integrator_for_azimuthal_invariance.pyx
+++ b/xpsi/cellmesh/integrator_for_azimuthal_invariance.pyx
@@ -44,6 +44,7 @@ ctypedef gsl_interp_accel accel
 ctypedef gsl_interp interp
 
 from .rays cimport eval_image_deflection
+from ..tools.core cimport are_equal
 
 from xpsi.surface_radiation_field.preload cimport (_preloaded,
                                                    init_preload,
@@ -325,7 +326,7 @@ def integrate(size_t numThreads,
                 psi = eval_image_deflection(I, acos(cos_psi))
                 sin_psi = sin(psi)
 
-                if psi != 0.0 and sin_psi == 0.0: # singularity at poles
+                if not are_equal(psi, 0.0) and are_equal(sin_psi, 0.0): # singularity at poles
                     # hack bypass by slight change of viewing angle
                     if cos_i >= 0.0:
                         _i = inclination + inclination * 1.0e-6 # arbitrary small

--- a/xpsi/cellmesh/integrator_for_azimuthal_invariance.pyx
+++ b/xpsi/cellmesh/integrator_for_azimuthal_invariance.pyx
@@ -361,7 +361,7 @@ def integrate(size_t numThreads,
                     # for spherical stars mu is defined, but for tilted local
                     # surface, there is not one unique value for mu because
                     # Einstein ring(s)
-                    if psi != 0.0:
+                    if not are_equal(psi, 0.0):
                         cos_delta = (cos_i - cos_theta_i * cos_psi) / (sin_theta_i * sin_psi)
                         if theta_i_over_pi < 0.5:
                             mu = mu + sin_alpha * sin_gamma * cos_delta
@@ -396,7 +396,7 @@ def integrate(size_t numThreads,
                                     _kdx = N_L - 1 - k # switch due to symmetry
 
                                 # phase asymmetric now
-                                if psi != 0.0:
+                                if not are_equal(psi, 0.0):
                                     cos_xi = sin_alpha * sin_i * sin(leaves[_kdx]) / sin_psi
                                     superlum = (1.0 + beta * cos_xi)
                                     eta = Lorentz / superlum

--- a/xpsi/cellmesh/integrator_for_azimuthal_invariance_split.pyx
+++ b/xpsi/cellmesh/integrator_for_azimuthal_invariance_split.pyx
@@ -44,6 +44,7 @@ ctypedef gsl_interp_accel accel
 ctypedef gsl_interp interp
 
 from .rays cimport eval_image_deflection
+from ..tools.core cimport are_equal
 
 from xpsi.surface_radiation_field.preload cimport (_preloaded,
                                                    init_preload,
@@ -341,7 +342,7 @@ def integrate(size_t numThreads,
                 psi = eval_image_deflection(I, acos(cos_psi))
                 sin_psi = sin(psi)
 
-                if psi != 0.0 and sin_psi == 0.0: # singularity at poles
+                if not are_equal(psi, 0.0) and are_equal(sin_psi, 0.0): # singularity at poles
                     # hack bypass by slight change of viewing angle
                     if cos_i >= 0.0:
                         _i = inclination + inclination * 1.0e-6 # arbitrary small

--- a/xpsi/cellmesh/integrator_for_azimuthal_invariance_split.pyx
+++ b/xpsi/cellmesh/integrator_for_azimuthal_invariance_split.pyx
@@ -377,7 +377,7 @@ def integrate(size_t numThreads,
                     # for spherical stars mu is defined, but for tilted local
                     # surface, there is not one unique value for mu because
                     # Einstein ring(s)
-                    if psi != 0.0:
+                    if not are_equal(psi, 0.0):
                         cos_delta = (cos_i - cos_theta_i * cos_psi) / (sin_theta_i * sin_psi)
                         if theta_i_over_pi < 0.5:
                             mu = mu + sin_alpha * sin_gamma * cos_delta
@@ -412,7 +412,7 @@ def integrate(size_t numThreads,
                                     _kdx = N_L - 1 - k # switch due to symmetry
 
                                 # phase asymmetric now
-                                if psi != 0.0:
+                                if not are_equal(psi, 0.0):
                                     cos_xi = sin_alpha * sin_i * sin(leaves[_kdx]) / sin_psi
                                     superlum = (1.0 + beta * cos_xi)
                                     eta = Lorentz / superlum

--- a/xpsi/cellmesh/integrator_for_time_invariance.pyx
+++ b/xpsi/cellmesh/integrator_for_time_invariance.pyx
@@ -263,7 +263,7 @@ def integrate(size_t numThreads,
                     sin_alpha = sqrt(1.0 - _cos_alpha * _cos_alpha)
                     mu = _cos_alpha * cos_gamma
 
-                    if psi != 0.0:
+                    if not are_equal(psi, 0.0):
                         cos_delta = (cos_i - cos_theta_i * cos_psi) / (sin_theta_i * sin_psi)
                         if theta_i_over_pi < 0.5:
                             mu = mu + sin_alpha * sin_gamma * cos_delta
@@ -271,7 +271,7 @@ def integrate(size_t numThreads,
                             mu = mu - sin_alpha * sin_gamma * cos_delta
 
                     if mu > 0.0:
-                        if sin_psi != 0.0:
+                        if not are_equal(sin_psi, 0.0):
                             cos_xi = sin_alpha * sin_i * sin(phi[i,j]) / sin_psi
                             superlum = (1.0 + beta * cos_xi)
                             eta = Lorentz / superlum

--- a/xpsi/cellmesh/integrator_for_time_invariance.pyx
+++ b/xpsi/cellmesh/integrator_for_time_invariance.pyx
@@ -41,6 +41,7 @@ ctypedef gsl_interp_accel accel
 ctypedef gsl_interp interp
 
 from .rays cimport eval_image_deflection
+from ..tools.core cimport are_equal
 
 from xpsi.surface_radiation_field.preload cimport (_preloaded,
                                                    init_preload,
@@ -229,7 +230,7 @@ def integrate(size_t numThreads,
                 cos_psi = _cos_psi
                 psi = eval_image_deflection(I, _psi)
                 sin_psi = sin(psi)
-                if psi != 0.0 and sin_psi == 0.0: # singularity at poles
+                if not are_equal(psi, 0.0) and are_equal(sin_psi, 0.0): # singularity at poles
                     # hack bypass by slight change of viewing angle
                     if cos_i >= 0.0:
                         _i = inclination + inclination * 1.0e-6 # arbitrary small

--- a/xpsi/cellmesh/mesh.pyx
+++ b/xpsi/cellmesh/mesh.pyx
@@ -12,6 +12,7 @@ from libc.stdlib cimport malloc, free
 from libc.stdio cimport printf
 
 from xpsi.cellmesh.mesh_tools cimport *
+from ..tools.core cimport are_equal
 
 cdef double _2pi = 2.0 * M_PI
 cdef double _hpi = 0.5 * M_PI
@@ -182,7 +183,7 @@ def construct_spot_cellMesh(size_t numThreads,
                 super_4[1] = super_4[1] + M_2PI
 
     # exploit symmetry if no superseding region offset
-    if superColatitude == cedeColatitude and superAzimuth == 0.0:
+    if are_equal(superColatitude, cedeColatitude) and are_equal(superAzimuth, 0.0):
         j_max = <size_t>(sqrt_numCell/2)
     else:
         j_max = sqrt_numCell
@@ -316,7 +317,7 @@ def construct_spot_cellMesh(size_t numThreads,
             elif p5 == 1:
                 cellAreas[i,j] = cellArea
 
-            if superColatitude == cedeColatitude and superAzimuth == 0.0:
+            if are_equal(superColatitude, cedeColatitude) and are_equal(superAzimuth, 0.0):
                 cellAreas[i,sqrt_numCell - 1 - j] = cellAreas[i,j]
 
             leftmost = rightmost

--- a/xpsi/cellmesh/mesh_tools.pyx
+++ b/xpsi/cellmesh/mesh_tools.pyx
@@ -7,6 +7,8 @@ from libc.math cimport M_PI, M_PI_2
 from libc.math cimport sqrt, sin, cos, tan, asin, acos, atan, fabs, exp, pow
 from libc.math cimport fmin, fmax, floor, ceil
 
+from ..tools.core cimport are_equal
+
 cdef double M_2PI = 2.0 * M_PI
 cdef double _c = 2.99792458e8
 cdef double _keV = 1.60217662e-16
@@ -96,7 +98,7 @@ cdef double f_theta(double mu,
 
 cdef double integrand(double theta, void *params) noexcept nogil:
 
-    if theta == 0.0:
+    if are_equal(theta, 0.0):
         return 0.0
 
     cdef:
@@ -169,7 +171,7 @@ cdef double eval_cedeAzi(double theta, double phi, double psi, double THETA) noe
     cdef double critical
 
     if THETA <= 0.0:
-        if cos(theta) == 0.0:
+        if are_equal(cos(theta),0.0):
             critical = M_PI_2
         else:
             critical = atan(tan(theta) * cos(phi))
@@ -196,9 +198,9 @@ cdef double eval_cedeAzi(double theta, double phi, double psi, double THETA) noe
                 return M_PI - azi
             elif 3.0*M_PI_2 < phi < M_2PI:
                 return azi + 2.0*M_PI
-            elif phi == 0.0 or phi == M_2PI:
+            elif are_equal(phi, 0.0) or are_equal(phi, M_2PI):
                 return 0.0
-            elif phi == M_PI:
+            elif are_equal(phi, M_PI):
                 return M_PI
         elif THETA < critical:
             if phi <= M_PI_2:
@@ -209,12 +211,12 @@ cdef double eval_cedeAzi(double theta, double phi, double psi, double THETA) noe
                 return azi + M_2PI
             elif 3.0*M_PI_2 < phi < M_2PI:
                 return M_PI - azi
-            elif phi == 0.0 or phi == M_2PI:
+            elif are_equal(phi, 0.0) or are_equal(phi, M_2PI):
                 return M_PI
-            elif phi == M_PI:
+            elif are_equal(phi, M_PI):
                 return 0.0
     else:
-        if cos(theta) == 0.0:
+        if are_equal(cos(theta), 0.0):
             critical = M_PI_2
         else:
             critical = atan(tan(theta) * cos(phi))
@@ -241,9 +243,9 @@ cdef double eval_cedeAzi(double theta, double phi, double psi, double THETA) noe
                 return M_PI - azi
             elif 3.0*M_PI_2 < phi < M_2PI:
                 return azi + 2.0*M_PI
-            elif phi == 0.0 or phi == M_2PI:
+            elif are_equal(phi, 0.0) or are_equal(phi, M_2PI):
                 return 0.0
-            elif phi == M_PI:
+            elif are_equal(phi, M_PI):
                 return M_PI
         elif THETA > critical:
             if phi <= M_PI_2:
@@ -254,9 +256,9 @@ cdef double eval_cedeAzi(double theta, double phi, double psi, double THETA) noe
                 return azi + M_2PI
             elif 3.0*M_PI_2 < phi < M_2PI:
                 return M_PI - azi
-            elif phi == 0.0 or phi == M_2PI:
+            elif are_equal(phi, 0.0) or are_equal(phi, M_2PI):
                 return M_PI
-            elif phi == M_PI:
+            elif are_equal(phi, M_PI):
                 return 0.0
 
 
@@ -300,7 +302,7 @@ cdef double get_interval(double a, double b, double LB, double UB) noexcept nogi
 
 cdef double cell_integrand(double theta, void *params) noexcept nogil:
 
-    if theta == 0.0:
+    if are_equal(theta, 0.0):
         return 0.0
 
     cdef double epsilon = (<double**> params)[0][0]
@@ -324,7 +326,7 @@ cdef double cell_integrand(double theta, void *params) noexcept nogil:
     cdef double aLB, aUB, cLB, cUB, delta_phi
 
     aUB = eval_phi(theta, colat, cedeRadius)
-    if aUB == -1.0:
+    if are_equal(aUB, -1.0):
         if theta + colat < cedeRadius:
             aUB = M_PI
             aLB = -M_PI
@@ -337,7 +339,7 @@ cdef double cell_integrand(double theta, void *params) noexcept nogil:
         cLB = cUB = 0.0
     else:
         cUB = eval_phi(theta, superCentreColat, superRadius)
-        if cUB == -1.0:
+        if are_equal(cUB, -1.0):
             return 0.0
         else:
             cLB = -cUB
@@ -484,7 +486,7 @@ cdef double integrateCell(double theta_a,
     cdef double thetas[4]
     cdef double theta_min, theta_max
 
-    if integral == 0.0:
+    if are_equal(integral, 0.0):
         #verbose = 1
         # repeat with verbose mode
         #gsl_integration_cquad(&F,
@@ -725,7 +727,7 @@ cdef double integrateCell(double theta_a,
 
 cdef double spot_integrand(double theta, void *params) noexcept nogil:
 
-    if theta == 0.0:
+    if are_equal(theta, 0.0):
         return 0.0
 
     cdef double epsilon = (<double*>params)[0]
@@ -750,7 +752,7 @@ cdef double spot_integrand(double theta, void *params) noexcept nogil:
     cdef double aLB, aUB, cLB, cUB, delta_phi
 
     aUB = eval_phi(theta, colat, cedeRadius)
-    if aUB == -1.0:
+    if are_equal(aUB, -1.0):
         if theta + colat < cedeRadius:
             aUB = M_PI
             aLB = -M_PI
@@ -763,7 +765,7 @@ cdef double spot_integrand(double theta, void *params) noexcept nogil:
         cLB = cUB = 0.0
     else:
         cUB = eval_phi(theta, superCentreColat, superRadius)
-        if cUB == -1.0:
+        if are_equal(cUB, -1.0):
             return 0.0
         else:
             cLB = -cUB
@@ -927,7 +929,7 @@ def allocate_cells(size_t num_cells,
             fast_super = 1.0
             fast_cede = 1.0
 
-        if fast_super == 0.0 and fast_cede == 0.0: # invisible (at this res)
+        if are_equal(fast_super, 0.0) and are_equal(fast_cede, 0.0): # invisible (at this res)
             fast_super = 1.0 # just assume equal and base on relative area
             fast_cede = 1.0
 
@@ -996,8 +998,8 @@ def allocate_cells(size_t num_cells,
     #print(superColatitude, superRadius)
     #print(holeRadius, holeColatitude, holeAzimuth)
 
-    if cedeRadius == 0.0: # no ceding region
-        if super_area == 0.0: # Gaussian integral did not resolve
+    if are_equal(cedeRadius, 0.0): # no ceding region
+        if are_equal(super_area, 0.0): # Gaussian integral did not resolve
             super_area = super_cellArea / 1000.0
         super_sqrt_numCell = ceil(sqrt((<double>num_cells) * super_cellArea / super_area))
         #print(super_sqrt_numCell)
@@ -1068,9 +1070,9 @@ def allocate_cells(size_t num_cells,
                                      Omega,
                                      w)
 
-        if super_area == 0.0: # Gausian integral did not resolve
+        if are_equal(super_area, 0.0): # Gausian integral did not resolve
             super_area = super_cellArea / 1000.0
-        if cede_area == 0.0: # Gausian integral did not resolve
+        if are_equal(cede_area, 0.0): # Gausian integral did not resolve
             cede_area = cede_cellArea / 1000.0
 
         if fast_super > 0.0:
@@ -1079,7 +1081,7 @@ def allocate_cells(size_t num_cells,
 
             y = ((1.0 - f)/f)*(cede_area/super_area) - 1.0
 
-            if y == 0.0:
+            if are_equal(y, 0.0):
                 super_numCell = 0.5 * <double>num_cells
                 cede_numCell = 0.5 * <double>num_cells
             else:

--- a/xpsi/cellmesh/polar_mesh.pyx
+++ b/xpsi/cellmesh/polar_mesh.pyx
@@ -12,6 +12,7 @@ from libc.stdlib cimport malloc, free
 from libc.stdio cimport printf
 
 from xpsi.cellmesh.mesh_tools cimport *
+from ..tools.core cimport are_equal
 
 cdef double _2pi = 2.0 * M_PI
 cdef double _hpi = 0.5 * M_PI
@@ -182,7 +183,7 @@ def construct_polar_cellMesh(size_t numThreads,
                 super_4[1] = super_4[1] + M_2PI
 
     # exploit symmetry if no superseding region offset
-    if superColatitude == cedeColatitude and superAzimuth == 0.0:
+    if are_equal(superColatitude, cedeColatitude) and are_equal(superAzimuth, 0.0):
         j_max = <size_t>(sqrt_numCell/2)
     else:
         j_max = sqrt_numCell
@@ -326,7 +327,7 @@ def construct_polar_cellMesh(size_t numThreads,
             elif p5 == 1:
                 cellAreas[i,j] = cellArea
 
-            if superColatitude == cedeColatitude and superAzimuth == 0.0:
+            if are_equal(superColatitude, cedeColatitude) and are_equal(superAzimuth, 0.0):
                 cellAreas[i,sqrt_numCell - 1 - j] = cellAreas[i,j]
 
             leftmost = rightmost

--- a/xpsi/likelihoods/_gaussian_likelihood_given_background_IQU.pyx
+++ b/xpsi/likelihoods/_gaussian_likelihood_given_background_IQU.pyx
@@ -12,6 +12,8 @@ from libc.math cimport pow, log, floor, fabs, pi
 from libc.stdlib cimport malloc, free
 from libc.stdio cimport printf
 
+from ..tools.core cimport are_equal
+
 from GSL cimport (gsl_interp,
                    gsl_interp_alloc,
                    gsl_interp_init,
@@ -153,7 +155,7 @@ def gaussian_likelihood_given_background(double exposure_time,
                 a = phases[j] + phase_shift
                 b = phases[j+1] + phase_shift
 
-                if b - a == 1.0:
+                if are_equal(b - a, 1.0):
                     a = 0.0
                     b = 1.0
                 else:

--- a/xpsi/likelihoods/_poisson_likelihood_given_background.pyx
+++ b/xpsi/likelihoods/_poisson_likelihood_given_background.pyx
@@ -9,6 +9,8 @@ cimport numpy as np
 from libc.math cimport pow, log, floor
 from libc.stdlib cimport malloc, free
 
+from ..tools.core cimport are_equal
+
 from GSL cimport (gsl_interp,
                    gsl_interp_alloc,
                    gsl_interp_init,
@@ -148,7 +150,7 @@ def poisson_likelihood_given_background(double exposure_time,
                 a = phases[j] + phase_shift
                 b = phases[j+1] + phase_shift
 
-                if b - a == 1.0:
+                if are_equal(b - a, 1.0):
                     a = 0.0
                     b = 1.0
                 else:

--- a/xpsi/likelihoods/_poisson_likelihood_given_background_IQU.pyx
+++ b/xpsi/likelihoods/_poisson_likelihood_given_background_IQU.pyx
@@ -12,6 +12,8 @@ from libc.math cimport pow, log, floor, fabs
 from libc.stdlib cimport malloc, free
 from libc.stdio cimport printf
 
+from ..tools.core cimport are_equal
+
 from GSL cimport (gsl_interp,
                    gsl_interp_alloc,
                    gsl_interp_init,
@@ -152,7 +154,7 @@ def poisson_likelihood_given_background(double exposure_time,
                 a = phases[j] + phase_shift
                 b = phases[j+1] + phase_shift
 
-                if b - a == 1.0:
+                if are_equal(b - a, 1.0):
                     a = 0.0
                     b = 1.0
                 else:

--- a/xpsi/likelihoods/default_background_marginalisation.pyx
+++ b/xpsi/likelihoods/default_background_marginalisation.pyx
@@ -9,6 +9,8 @@ cimport numpy as np
 from libc.stdlib cimport malloc, free
 from libc.math cimport exp, pow, log, sqrt, fabs, floor
 
+from ..tools.core cimport are_equal
+
 ctypedef np.uint8_t uint8
 
 from GSL cimport (gsl_interp,
@@ -114,7 +116,7 @@ cdef double marginal_integrand(double B, void *params) noexcept nogil:
         c = a.SCALE * (a.star[j] + B)
         if c > 0.0:
             x += a.data[j] * log(c) - c
-        elif c == 0.0 and a.data[j] == 0.0:
+        elif are_equal(c, 0.0) and are_equal(a.data[j], 0.0):
             #x += log(1) = 0
             pass
         else:
@@ -388,7 +390,7 @@ def eval_marginal_likelihood(double exposure_time,
                     pa = phases[j] + phase_shift
                     pb = phases[j+1] + phase_shift
 
-                    if pb - pa == 1.0:
+                    if are_equal(pb - pa, 1.0):
                         pa = 0.0
                         pb = 1.0
                     else:
@@ -453,7 +455,7 @@ def eval_marginal_likelihood(double exposure_time,
         a.star = &(STAR[i,0])
         a.T_exp = exposure_time
 
-        if av_DATA == 0.0 and av_STAR == 0.0:
+        if are_equal(av_DATA, 0.0) and are_equal(av_STAR, 0.0):
             # zero counts in channel and zero hot region signal
 
             lower = 0.0
@@ -473,15 +475,15 @@ def eval_marginal_likelihood(double exposure_time,
             if B <= B_min:
                 min_counts = -1.0
                 for j in range(0, a.n):
-                    if STAR[i,j] == 0.0:
+                    if are_equal(STAR[i,j], 0.0):
                         min_counts = -2.0
                         break
-                if min_counts == -2.0:
+                if are_equal(min_counts, -2.0):
                     for j in range(0, a.n):
-                        if (min_counts == -2.0 and counts[i,j] > 0.0) or (0.0 < counts[i,j] < min_counts):
+                        if (are_equal(min_counts, -2.0) and counts[i,j] > 0.0) or (0.0 < counts[i,j] < min_counts):
                             min_counts = counts[i,j]
-                if min_counts != -1.0:
-                    if min_counts == -2.0:
+                if not are_equal(min_counts, -1.0):
+                    if are_equal(min_counts, -2.0):
                         B = 0.0
                         B_min = 0.0
                     else:
@@ -558,7 +560,7 @@ def eval_marginal_likelihood(double exposure_time,
                 c = a.SCALE * (a.star[j] + B_for_integrand)
                 if c > 0.0:
                     a.A += a.data[j] * log(c) - c
-                elif c == 0.0 and a.data[j] == 0.0:
+                elif are_equal(c, 0.0) and are_equal(a.data[j], 0.0):
                     #a.A += log(1)
                     pass
                 else:

--- a/xpsi/pixelmesh/RODES_qK.pyx
+++ b/xpsi/pixelmesh/RODES_qK.pyx
@@ -8,6 +8,8 @@ from libc.stdio cimport printf
 from GSL cimport GSL_SUCCESS
 from xpsi.pixelmesh.METRIC_qK cimport *
 
+from ..tools.core cimport are_equal
+
 cdef double _pi = M_PI
 
 # Partial derivatives of the metric tensor with respect to coordinates r and \theta
@@ -321,7 +323,7 @@ cdef int RODES(double t,
     dydl[0] = (G_44 + b*G_14) / (G_11*G_44 - G_14*G_14) # Reduce #flops here
 
     # Had only the second condition, thus phase-shifting for finite omega parameter...
-    if a == 0.0 and X_IP == 0.0:
+    if are_equal(a, 0.0) and are_equal(X_IP, 0.0):
         dydl[1] = 0.0
     else:
         dydl[1] = -1.0 * (b*G_11 + G_14) / (G_11*G_44 - G_14*G_14)
@@ -339,9 +341,9 @@ cdef int RODES(double t,
     # both of the angles are zero, leading to slow evolution because the
     # relative error is small but the derivative(s) are not set to precisely
     # zero.
-    if a == 0.0 and X_IP == 0.0 and Y_IP == 0.0:
+    if are_equal(a, 0.0) and are_equal(X_IP, 0.0) and are_equal(Y_IP, 0.0):
         dydl[5] = 0.0
-    elif a == 0.0 and Y_IP == 0.0 and inclination == _pi/2.0:
+    elif are_equal(a, 0.0) and are_equal(Y_IP, 0.0) and are_equal(inclination, _pi/2.0):
         dydl[5] = 0.0
     else:
         dydl[5] = (-Gamma_theta[0]*dydl[0]*dydl[0]

--- a/xpsi/pixelmesh/globalRayMap.pyx
+++ b/xpsi/pixelmesh/globalRayMap.pyx
@@ -25,6 +25,8 @@ from xpsi.pixelmesh.RK_IP2S_tracer cimport RK
 from xpsi.pixelmesh.surfaceBisection cimport ZABB
 from xpsi.pixelmesh.get_IP_radius cimport compute_imagePlane_radius
 
+from ..tools.core cimport are_equal
+
 cdef int SUCCESS = 0
 
 cdef double _2pi = 2.0 * M_PI
@@ -141,7 +143,7 @@ cdef int compute_globalRayMap(size_t numThreads,
 
     #printf("\nOrigin (Z, ABB): (%.8e, %.8e)", MAP.ORIGIN[4], MAP.ORIGIN[5])
 
-    if GEOM.a == 0.0 and GEOM.kappa == 0.0:
+    if are_equal(GEOM.a, 0.0) and are_equal(GEOM.kappa, 0.0):
         # calibration for Schwarzschild equatorial b=0 ray
         MAP.refRayTime = GEOM.d - GEOM.R_eq
         MAP.refRayTime += GEOM.r_s * log((GEOM.d - GEOM.r_s) / (GEOM.R_eq - GEOM.r_s))

--- a/xpsi/surface_radiation_field/hot_wrapper.pyx
+++ b/xpsi/surface_radiation_field/hot_wrapper.pyx
@@ -1,6 +1,7 @@
 cdef size_t atmos_extension = 1
 
 from libc.stdio cimport printf
+from ..tools.core cimport are_equal
 
 #Blackbody
 from xpsi.surface_radiation_field.hot_BB cimport (init_hot_BB,
@@ -160,7 +161,7 @@ cdef double eval_hot_I(size_t THREAD,
             I_nom = I_nom + mu_imu*I_hot_imu*dmu
             #I_denom_test = I_denom_test + mu_imu*dmu
             #printf("%d,%.8e,%.8e,%.8e,%.8e,%.8e\n",imu,mu_imu,dmu,I_denom,I_denom_test,I_denom_test*I_nsx_imu)
-        if I_denom == 0.0:
+        if are_equal(I_denom, 0.0):
             I_hot_beam = 0.0
         else:
             I_hot_beam = (I_nom/I_denom)*(1.0+abb*((E)**cbb)*mu+bbb*((E)**dbb)*mu**2)*I_hot

--- a/xpsi/tools/core.pxd
+++ b/xpsi/tools/core.pxd
@@ -8,3 +8,5 @@ from GSL cimport (gsl_interp_type,
 cdef const gsl_interp_type* _get_phase_interpolant() except *
 
 cdef const gsl_interp_type* _get_energy_interpolant() except *
+
+cdef bint are_equal(double x, double y, double epsilon=*) noexcept nogil

--- a/xpsi/tools/core.pyx
+++ b/xpsi/tools/core.pyx
@@ -16,6 +16,8 @@ from .energy_interpolator import energy_interpolator
 from .synthesise import synthesise_exposure
 from .synthesise import synthesise_given_total_count_number
 
+from libc.math cimport fabs
+
 __interpolants__ = {'Akima': 0, 'Steffen': 1, 'Cubic': 2}
 
 def get_phase_interpolant():
@@ -112,3 +114,9 @@ cdef const gsl_interp_type* _get_energy_interpolant() except *:
             return gsl_interp_cspline
         else:
             raise ValueError('Invalid eneergy interpolant setting.')
+
+cdef bint are_equal(double x, double y, double epsilon = 1.0e-12) noexcept nogil:
+    if(fabs(x - y) < epsilon):
+        return True
+    else:
+        return False


### PR DESCRIPTION
All the double == double comparisons that I found (at least in the Cython codes) were replaced with `are_equal()` function that I placed in `tools/core.pyx` and that allows 1e-12 tolerance (by default) around the exact value.

I tested a couple of the test example runs, that they give still the same results as before.