### PR TITLE
Fixing Changelog appearance in docs

### DIFF
--- a/docs/source/changelog_docs.rst
+++ b/docs/source/changelog_docs.rst
@@ -1,0 +1,3 @@
+.. _history:
+
+.. include:: ../../CHANGELOG.rst

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -1,3 +1,7 @@
-.. _history:
+History
+===============
 
-.. include:: ../../CHANGELOG.rst
+.. toctree::
+   :maxdepth: 1
+
+   changelog_docs


### PR DESCRIPTION
Fixing the broken History/Changelog appearance in the documentation pages (to not show all the subtitles in the side bar).