### PR TITLE
Numerical atmos test runs fixed to not go beyond atmosphere table limits.

### DIFF
--- a/changelog.d/605.attribution.rst
+++ b/changelog.d/605.attribution.rst
@@ -1,0 +1,1 @@
+Tuomo Salmi

--- a/changelog.d/605.fixed.rst
+++ b/changelog.d/605.fixed.rst
@@ -1,0 +1,1 @@
+Fixed the example runs with numerical atmosphere data to not extrapolate beyond the atmosphere table limits.

--- a/examples/examples_modeling_tutorial/TestRun_Num.py
+++ b/examples/examples_modeling_tutorial/TestRun_Num.py
@@ -114,7 +114,10 @@ spacetime = xpsi.Spacetime(bounds=bounds, values=dict(frequency=300.0))
 bounds = dict(super_colatitude = (None, None),
               super_radius = (None, None),
               phase_shift = (0.0, 0.1),
-              super_temperature = (5.1, 6.8))
+              super_temperature = (5.3, 6.8))
+#Note: The atmosphere table lower limit is 5.1, but we use 5.3 in this example,
+#because the secondary spot temperature is defined to be always 0.2 below the
+#primary spot temperature (just for demonstrating how to derive parameters)
 
 primary = xpsi.HotRegion(bounds=bounds,
                         values={},

--- a/examples/examples_modeling_tutorial/TestRun_Num.py
+++ b/examples/examples_modeling_tutorial/TestRun_Num.py
@@ -117,7 +117,7 @@ bounds = dict(super_colatitude = (None, None),
               super_temperature = (5.3, 6.8))
 #Note: The atmosphere table lower limit is 5.1, but we use 5.3 in this example,
 #because the secondary spot temperature is defined here to be always 0.2 below
-#the primary spot temperature (just for demonstrating how to derive parameters)
+#the primary spot temperature (just for demonstrating how to derive parameters).
 
 primary = xpsi.HotRegion(bounds=bounds,
                         values={},

--- a/examples/examples_modeling_tutorial/TestRun_Num.py
+++ b/examples/examples_modeling_tutorial/TestRun_Num.py
@@ -116,8 +116,8 @@ bounds = dict(super_colatitude = (None, None),
               phase_shift = (0.0, 0.1),
               super_temperature = (5.3, 6.8))
 #Note: The atmosphere table lower limit is 5.1, but we use 5.3 in this example,
-#because the secondary spot temperature is defined to be always 0.2 below the
-#primary spot temperature (just for demonstrating how to derive parameters)
+#because the secondary spot temperature is defined here to be always 0.2 below
+#the primary spot temperature (just for demonstrating how to derive parameters)
 
 primary = xpsi.HotRegion(bounds=bounds,
                         values={},

--- a/examples/examples_modeling_tutorial/TestRun_NumBeam.py
+++ b/examples/examples_modeling_tutorial/TestRun_NumBeam.py
@@ -117,10 +117,13 @@ spacetime = xpsi.Spacetime(bounds=bounds, values=dict(frequency=300.0), star_sha
 bounds = dict(super_colatitude = (None, None),
               super_radius = (None, None),
               phase_shift = (0.0, 0.1),
-              super_temperature = (5.1, 6.8),
+              super_temperature = (5.3, 6.8),
               super_abb = (-0.7, 0.7),
-              super_bbb = (-0.7, 0.7))              
-	                    
+              super_bbb = (-0.7, 0.7))
+#Note: The atmosphere table lower limit is 5.1, but we use 5.3 in this example,
+#because the secondary spot temperature is defined to be always 0.2 below the
+#primary spot temperature (just for demonstrating how to derive parameters)
+
 from modules.CustomHotRegion_Beaming import CustomHotRegion
 
 primary =  CustomHotRegion(bounds=bounds,
@@ -539,7 +542,7 @@ runtime_params = {'resume': False,
                   'importance_nested_sampling': False,
                   'multimodal': False,
                   'n_clustering_params': None,
-                  'outputfiles_basename': './run/run_Num',
+                  'outputfiles_basename': './run/run_NumBeam',
                   'n_iter_before_update': 50,
                   'n_live_points': 50,
                   'sampling_efficiency': 0.8,

--- a/examples/examples_modeling_tutorial/TestRun_NumBeam.py
+++ b/examples/examples_modeling_tutorial/TestRun_NumBeam.py
@@ -121,8 +121,8 @@ bounds = dict(super_colatitude = (None, None),
               super_abb = (-0.7, 0.7),
               super_bbb = (-0.7, 0.7))
 #Note: The atmosphere table lower limit is 5.1, but we use 5.3 in this example,
-#because the secondary spot temperature is defined to be always 0.2 below the
-#primary spot temperature (just for demonstrating how to derive parameters)
+#because the secondary spot temperature is defined here to be always 0.2 below
+#the primary spot temperature (just for demonstrating how to derive parameters).
 
 from modules.CustomHotRegion_Beaming import CustomHotRegion
 


### PR DESCRIPTION
The additional checks making sure that atmosphere table bounds are not exceeded are causing the TestRun_Num.py and TestRun_NumBeam.py fail with an error message. So far this issue was not noticed because going beoynd limits was not prevented.