### PR TITLE
Adding eXTP white paper to publications list

### DIFF
--- a/docs/source/applications.rst
+++ b/docs/source/applications.rst
@@ -26,7 +26,7 @@ NICER rotation-powered millisecond pulsar papers
 
 X-PSI has been used in several Pulse Profile Modeling analysis papers using *NICER* data of rotation-powered millisecond pulsars. These are typically published with a Zenodo repository containing data, model files, X-PSI scripts, samples and post-processing notebooks to enable full reproduction and independent analysis. 
 
-**Mauviard et al. 2025** `(ApJ submitted) <https://ui.adsabs.harvard.edu/abs/2025arXiv250614883M/abstract>`_ *A NICER view of the 1.4 solar-mass edge-on pulsar PSR J0614--3329*. See also the associated `Zenodo repository`__.
+**Mauviard et al. 2025** `(ApJ in press) <https://ui.adsabs.harvard.edu/abs/2025arXiv250614883M/abstract>`_ *A NICER view of the 1.4 solar-mass edge-on pulsar PSR J0614--3329*. See also the associated `Zenodo repository`__.
 
 .. _Zenodo25mauviard: https://doi.org/10.5281/zenodo.15603406
 __ Zenodo25mauviard_
@@ -99,7 +99,7 @@ __ Zenodo_
 
 
 PPM for accreting/bursting neutron stars
-****************************************
+****************************************  
 
 **Das et al. 2025** `(ApJ, 987, 34) <https://ui.adsabs.harvard.edu/abs/2025ApJ...987...34D/abstract>`_ *Pulse Profiles of Accreting Neutron Stars from GRMHD Simulations*.
 
@@ -136,6 +136,8 @@ __ Zenodo23kini_
 
 General PPM studies
 *******************
+
+**Li et al. 2025** `(Science China Physics, Mechanics & Astronomy, 68, 119503) <https://ui.adsabs.harvard.edu/abs/2025SCPMA..6819503L/abstract>`_ *Dense matter in neutron stars with eXTP*. X-PSI is used for AMXP PPM simulations for eXTP.
 
 **Bootsma et al. 2025** `(MNRAS, 537, 3769) <https://ui.adsabs.harvard.edu/abs/2025MNRAS.537.3769B/abstract>`_ *Scaling relations for the uncertainty in neutron star radius inferred from pulse profile modelling: the effect of spin rate*. See also the associated `Zenodo repository`__.
 


### PR DESCRIPTION
Adding the eXTP white paper to publications list (putting simulations papers in the 'General PPM studies' section of the publications list).