### PR TITLE
Added two small features to the corner plotter

### DIFF
--- a/changelog.d/619.added.rst
+++ b/changelog.d/619.added.rst
@@ -1,0 +1,3 @@
+Added the possibility to add custom legend labels in the corner plot. This has become necessary as the multi-modal cornerplot gives default name to new modes. This can be done with a new parameter in the ``CornerPlotter.plot()`` function such as ``legend_labels=['list','of','my','labels']``.
+
+Now, if the priors are identical (i.e. ``priors_identical=True`` in ``CornerPlotter.plot()``), plot them in black.

--- a/xpsi/PostProcessing/_corner.py
+++ b/xpsi/PostProcessing/_corner.py
@@ -499,7 +499,10 @@ class CornerPlotter(PostProcessor):
             contour_args = self.get_attr('contours')
             contour_args.reverse()
 
-            if len(getdist_bcknds) == 1:
+            if "legend_labels" in kwargs:
+                legend_labels = kwargs.pop('legend_labels')
+                assert len(legend_labels) == len(getdist_bcknds), 'There must be as many legend labels as runs to plot.'
+            elif len(getdist_bcknds) == 1:
                 legend_labels = None
             elif len(self._subset) > 1:
                 legend_labels = self.get_attr('parent_ID')
@@ -672,7 +675,8 @@ class CornerPlotter(PostProcessor):
                             bootstrap = bootstrap,
                             n_simulate = kwargs.get('n_simulate'),
                             force_draw = force_draw_i,
-                            prior_samples_fname=prior_samples_fname)
+                            prior_samples_fname=prior_samples_fname,
+                            priors_identical=priors_identical)
 
                 if (i==0 and priors_identical):
                     break
@@ -754,7 +758,8 @@ class CornerPlotter(PostProcessor):
                            KL_divergence, KL_base,
                            bootstrap, n_simulate,
                            force_draw,
-                           prior_samples_fname):
+                           prior_samples_fname,
+                           priors_identical=False):
         """ Crudely estimate the prior density.
 
         Kullback-Leibler divergence estimated in bits for a combined run or
@@ -790,6 +795,8 @@ class CornerPlotter(PostProcessor):
                  _np.save(samples_npy,samples)
 
         color, lw = (run.contours[key] for key in ('color', 'lw'))
+        if priors_identical:
+            color = 'black'
 
         quantiles = [None] * 3
 


### PR DESCRIPTION
Added the possibility to add custom legend labels in the corner plot. This has become necessary as the multi-modal cornerplot gives default name to new modes. This can be done with a new parameter in the ``CornerPlotter.plot()`` function such as ``legend_labels=['list','of','my','labels']``.

Another added feature is that now, if the priors are identical (i.e. ``priors_identical=True`` in ``CornerPlotter.plot()``), plot them in black. This avoids confusion in the case of many runs with a general shared prior that has same color as a single run.

Can anyone go over this quickly ? Should be straightforward