### PR TITLE
Removing build_docs release trigger

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  release:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Removes the command triggering build_docs on a new release, since this seems to cause problems and results in new releases not being sent to Zenodo.   Solution suggested by @thjsal .