### PR TITLE
Implementing nautilus-sampler

### DIFF
--- a/xpsi/NautilusSampler.py
+++ b/xpsi/NautilusSampler.py
@@ -1,0 +1,113 @@
+from xpsi import _verbose
+from xpsi.Likelihood import Likelihood
+from xpsi.Prior import Prior
+
+import numpy as np
+import os
+
+try:
+    import nautilus
+
+except ImportError:
+    print('Check your nautilus-sampler installation. (pip install nautilus-sampler)')
+    raise
+else:
+    if _verbose:
+        print('Imported Nautilus.')
+
+
+class NautilusSampler:
+    """ Wrapper for the Nautilus (https://nautilus-sampler.readthedocs.io/) package (Lange 2023).
+
+    :param likelihood: An instance of :class:`~.Likelihood.Likelihood`.
+
+    :param prior: An instance of :class:`~.Prior.Prior`.
+
+    :param sampler_build_kwargs: A dictionary of the keyword arguments passed to the instance of :class:`nautilus.Sampler`.
+
+    """
+
+    def __init__(
+        self,
+        likelihood : Likelihood,
+        prior : Prior,
+        sampler_build_kwargs,
+        MPI=True,
+    ):
+
+        if not isinstance(likelihood, Likelihood):
+            raise TypeError('Invalid type for likelihood object.')
+        self._likelihood = likelihood
+
+        if not isinstance(prior, Prior):
+            raise TypeError('Invalid type for prior object.')
+        self._prior = prior
+
+        self._param_names = self._likelihood.names
+
+        if MPI:
+            from mpi4py.futures import MPIPoolExecutor
+
+            self._sampler = nautilus.Sampler(
+                self._prior.inverse_sample, # prior
+                self.likelihood_wrapper,
+                n_dim=len(self._param_names),
+                pass_dict=False,
+                pool = MPIPoolExecutor(),
+                **sampler_build_kwargs
+            )
+
+        else:
+
+            self._sampler = nautilus.Sampler(
+                self._prior.inverse_sample, # prior
+                self.likelihood_wrapper,
+                n_dim=len(self._param_names),
+                pass_dict=False,
+                **sampler_build_kwargs
+            )
+
+    def __call__(self, runtime_params):
+        """ Run the sampler until target convergence criteria are fulfilled with the
+        given runtime parameters.
+
+        :param runtime_params: A dictionary of the keyword arguments passed to :func:`run`.
+
+        """
+
+        self._sampler.run(**runtime_params)
+
+    def likelihood_wrapper(self, params):
+        """Calculate the loglikelihood value for a given set of parameter values.
+        Copy-pasted from UltraNestSampler interface.
+
+        :param params: List of parameter values.
+
+        :returns: Float with loglikelihood value for given set of parameter values.
+
+        """
+
+        arg1, *args = params
+
+        # calculate the log-likelihood
+        nautilus_likelihood = self._likelihood(p=[arg1, *args], reinitialise=True)
+
+        if isinstance(nautilus_likelihood, np.ndarray):  # hackish way around: need to find better solution for this
+            nautilus_likelihood = nautilus_likelihood[0]
+
+        return nautilus_likelihood
+
+    def write_results(self, out_filename):
+        """ Get output txt file with columns containing weights, -2*loglikelihood,
+        and parameters, which is the format required for post-processing within X-PSI.
+        This is additional to output files UltraNest produces.
+
+        :param out_filename: String specifying the name of the output file.
+
+        """
+        # extract results
+        data, weights, logl = self._sampler.posterior()
+
+        # save extra output file special for xpsi post-processing
+        output = np.column_stack((weights, -2 * logl, data))
+        np.savetxt(f"{out_filename}.txt", output)

--- a/xpsi/Sample.py
+++ b/xpsi/Sample.py
@@ -411,8 +411,24 @@ def run_nautilus(
     MPI=True,
     out_filename="weighted_post_nautilus_xpsi"
 ):
-    """
-    Coucou
+    """  Wrapper for the nautilus-sampler (https://nautilus-sampler.readthedocs.io/en/latest/)
+
+    :param likelihood: An instance of :class:`~.Likelihood.Likelihood`.
+
+    :param prior: An instance of :class:`~.Prior.Prior`.
+
+    :param sampler_params: A dictionary of the keyword arguments passed to the
+        instance of :class:`~.NautilusSampler` to initialise the sampler.
+
+    :param runtime_params:  A dictionary of the keyword arguments passed to the
+        instance of :class:`~.NautilusSampler` to run the sampler.
+
+    :param bool MPI:
+        Whether to use MPI or not for parallelized sampling.
+
+    :param out_filename: String specifying the name of the output file.
+
+    :returns: An instance of :class:`~.NautilusSampler`
     """
 
     # initialise the sampler

--- a/xpsi/Sample.py
+++ b/xpsi/Sample.py
@@ -1,4 +1,4 @@
-__all__ = ["run_multinest", "run_emcee", "run_ultranest"]
+__all__ = ["run_multinest", "run_emcee", "run_ultranest", "run_nautilus"]
 
 from xpsi.global_imports import *
 from xpsi import _comm, _rank, _size
@@ -18,6 +18,11 @@ try:
     from xpsi.UltranestSampler import UltranestSampler
 except ImportError:
     print("""Check your installation of UltraNest if using the UltranestSampler""")
+try:
+    from xpsi.NautilusSampler import NautilusSampler
+except ImportError:
+    print("""Check your installation of nautilus-sampler if using the NautilusSampler""")
+
 
 posterior = None
 
@@ -396,3 +401,27 @@ def ultranested(likelihood,
                          use_stepsampler=use_stepsampler,
                          stepsampler_params=stepsampler_params,
                          out_filename=out_filename)
+
+
+def run_nautilus(
+    likelihood,
+    prior,
+    sampler_build_kwargs={},
+    runtime_params={},
+    MPI=True,
+    out_filename="weighted_post_nautilus_xpsi"
+):
+    """
+    Coucou
+    """
+
+    # initialise the sampler
+    sampler = NautilusSampler(likelihood, prior, sampler_build_kwargs, MPI=MPI)
+
+    # start sampling
+    sampler(runtime_params)
+
+    # store output
+    sampler.write_results(out_filename)
+
+    return sampler


### PR DESCRIPTION
Hi there, I am @lmauviard office mate, and I am dealing a lot with nested sampling with slow-to-evaluate likelihoods recently. After discussing, I went on and implemented a draft of `nautilus-sampler` integration for `xpsi`. 

For a bit of context, [`nautilus`](https://nautilus-sampler.readthedocs.io/en/latest/) is a nested-sampling algorithm that uses machine learning to increase the speed of convergence and reduce the required number of likelihood evaluations. The main idea is to learn an approximation of the given bounded volume at a given iteration using multiple MLPs and the already evaluated points. See [the article](https://academic.oup.com/mnras/article/525/2/3181/7243406?login=false) for more context. 

Doing so, the proposal is much more efficient compared to ellipsoids as in `Multinest` or local ellipsoids as in `Ultranest`. In our applications (X-ray spectroscopy), we were able to go from ~23M likelihood calls (with `Ultranest` + step sampler) to ~400k, without any loss on the estimated evidence, and posterior distributions that are perfectly comparable. I would be extremely curious to see how this kind of algorithm performs with the highly skewed and multimodal distributions you are dealing with, thus the draft PR. 

I ran the introduction example with a bunch of parameters fixed (to speed up the sampling on my computer) with `Multinest` (1000 live points) and `nautilus` (2000 live points), and obtained respectively logZ = -27582.12 and logZ = -27583.41, for respectively 80k likelihood evaluations and 120k likelihood evaluations. It might look like `nautilus` underperformed here, but it had more live points, and it is good to know that `nautilus` can re-run after the first nested sampling, using the learnt volumes. Doing so, it performs some sort of importance sampling to estimate the Evidence, and it should unbias the result from the peculiarity of the run, but require extra likelihood evaluations (that are performed at an extremely high sampling efficiency, so this additional cost is really worth). 

I am currently running both `Multinest` and `nautilus` with 5k live points each, to see how they compare in a higher live point regime. In general, `nautilus` scales much better with the number of live points compared to other algorithms, so you shouldn't be afraid to put this much. 

Files to replicate the run : I didn't use MPI, however, it looks like [`nautilus` as an integration for it that](https://nautilus-sampler.readthedocs.io/en/latest/guides/parallelization.html#mpi-parallelization) that I "sorta" implemented, but this should be test under real conditions.

[intro-nautilus.py](https://github.com/user-attachments/files/26815320/intro-nautilus.py)
[intro-multinest.py](https://github.com/user-attachments/files/26815324/intro-multinest.py)
