### PR TITLE
Fixed the backscale for signal synthesization

### DIFF
--- a/changelog.d/709.fixed.rst
+++ b/changelog.d/709.fixed.rst
@@ -1,0 +1,1 @@
+Fixed the Signal.synthesize method when using data_BKG, which previously resulted in overestimated background contribution.

--- a/xpsi/Signal.py
+++ b/xpsi/Signal.py
@@ -829,9 +829,8 @@ class Signal(ParameterSubspace):
                 else:
                     BKG = data_BKG
 
-                # Apply backscal
-                BKG *= backscal_ratio
-                bkg_cts = BKG.sum()
+                # Apply backscal to get the right total number of bkg counts
+                bkg_cts = BKG.sum() / backscal_ratio
 
             # Otherwise, use null background
             else:


### PR DESCRIPTION
Previously misused the input `data_BKG` in the `Signal.synthesize` method, which resulted in overestimation of the background in the generated expected counts. 

This is now fixed and `data_BKG` is actually the data counts spectrum, that will be rescaled by the backscal ratio. 