### PR TITLE
Corrections for `Everywhere` usage

### DIFF
--- a/changelog.d/719.attribution.rst
+++ b/changelog.d/719.attribution.rst
@@ -1,0 +1,1 @@
+Christine Kazantsev

--- a/changelog.d/719.changed.rst
+++ b/changelog.d/719.changed.rst
@@ -1,0 +1,6 @@
+includes:
+
+- correction of background plotter in the case of an `Everywhere`, where there are no phases, in which case the new integration returned 0. Now if `len(phases)=1`, the 1D spectrum is returned.
+- in the case of a table atmosphere, check of whether T and log g are within atmosphere table bounds in `Photosphere`. Identical to the `Elsewhere` checks.
+- in the pileup module, `psf_frac` is now allowed to go down to 0, which can be useful when comparing to a "no pileup" case
+

--- a/xpsi/Instrument.py
+++ b/xpsi/Instrument.py
@@ -191,7 +191,6 @@ class Instrument(ParameterSubspace):
         """
         matrix = self.construct_matrix()
 
-        self.unfolded_spectrum = signal
         self._cached_signal = _np.dot(matrix[orange[0]:orange[1],
                                              irange[0]:irange[1]], signal)
 
@@ -544,7 +543,6 @@ class InstrumentPileup(Instrument):
 
     def __call__(self, signal, *args):
         """ Overwrite. """
-        self.unfolded_spectrum = signal
         
         ## Compute spectrum with pileup
         piled_spectrum = self.pileup.analyze(signal,

--- a/xpsi/Instrument.py
+++ b/xpsi/Instrument.py
@@ -191,6 +191,7 @@ class Instrument(ParameterSubspace):
         """
         matrix = self.construct_matrix()
 
+        self.unfolded_spectrum = signal
         self._cached_signal = _np.dot(matrix[orange[0]:orange[1],
                                              irange[0]:irange[1]], signal)
 
@@ -543,6 +544,8 @@ class InstrumentPileup(Instrument):
 
     def __call__(self, signal, *args):
         """ Overwrite. """
+        self.unfolded_spectrum = signal
+        
         ## Compute spectrum with pileup
         piled_spectrum = self.pileup.analyze(signal,
                                              alpha=self['grade_migration'],
@@ -578,7 +581,7 @@ class InstrumentPileup(Instrument):
                     value = values.get('grade_migration', None))
     
         psffrac = Parameter('psf_fraction',
-                    strict_bounds = (0.8,1.0),  #min in sherpa set at 0.85
+                    strict_bounds = (0.0,1.0),  #min in sherpa set at 0.85
                     bounds = bounds.get('psf_fraction', None),
                     doc = 'fraction of events in the source extraction region to which pileup will be applied',
                     symbol = r'$PSF_frac',

--- a/xpsi/Photosphere.py
+++ b/xpsi/Photosphere.py
@@ -527,6 +527,25 @@ class Photosphere(ParameterSubspace):
                         raise Exception("Surface gravity ", g, "is outside of the atmosphere table bounds: [",g_low, g_high,"]")
 
         #TBD: Similar check for Everywhere.
+        if self._everywhere is not None:
+            if self._everywhere.atm_ext == 2: #Num4D extension assumed to be used only in nsx-format. If not, user needs to customize.
+                T_low, T_high = self._everywhere_atmosphere[0][0], self._everywhere_atmosphere[0][len(self._everywhere_atmosphere[0])-1]
+                g_low, g_high = self._everywhere_atmosphere[1][0], self._everywhere_atmosphere[1][len(self._everywhere_atmosphere[1])-1]
+
+                temperature = self._everywhere[0]
+
+                if not T_low <= temperature <= T_high:
+                    raise Exception(" Everywhere temperature ", temperature, "is outside of the atmosphere table bounds: [",T_low, T_high,"]")
+
+                ref = self._spacetime
+                grav = effective_gravity(_np.array([1.0, 0.0]),
+                                        _np.array([ref.R] * 2 ),
+                                        _np.array([ref.zeta] * 2),
+                                        _np.array([ref.epsilon] * 2))
+
+                for g in grav:
+                    if not g_low <= g <= g_high:
+                        raise Exception("Surface gravity ", g, "is outside of the atmosphere table bounds: [",g_low, g_high,"]")
 
         if self._everywhere is not None:
             if self._stokes:

--- a/xpsi/utilities/BackgroundTools.py
+++ b/xpsi/utilities/BackgroundTools.py
@@ -190,7 +190,9 @@ def plotBackgroundSpectrum( XPSI_model,
 
     # Get expected counts from both spots
     num_components = signal.num_components
-    HotRegion_spectra = np.array( [ integrate.simpson( y=signal.signals[i], x=signal.phases[i] , axis=1 ) * data.exposure_time for i in range(num_components)] )
+    ## integral over phases if phases are defined, else simply plot the spectrum
+    HotRegion_spectra = np.array( [ integrate.simpson( y=signal.signals[i], x=signal.phases[i] , axis=1 ) * data.exposure_time if len(signal.phases[i])>1
+                                   else np.sum(signal.signals[i], axis=1) * data.exposure_time for i in range(num_components)] )
     Expected_Spectrum = signal.expected_counts.sum(axis = 1) 
     print( f"Maximum counts in an energy bin : {np.max( HotRegion_spectra.sum(axis=0) )}")
     


### PR DESCRIPTION
includes:
- correction of background plotter in the case of an Everywhere, where there are no phases, in which case the new integration returned 0
- check of whether T and log g are within atmosphere table bounds in `Photosphere`, identical to the `Elsewhere` checks
- in the pileup module, psf_frac is now allowed to go down to 0, which can be useful when comparing to a "no pileup" case